### PR TITLE
enhancement: Port Navigation components to Vue

### DIFF
--- a/packages/vue/src/__tests__/navigation/breadcrumbs.test.ts
+++ b/packages/vue/src/__tests__/navigation/breadcrumbs.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/vue';
+import { Breadcrumbs } from '../../components/navigation';
+
+const testItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Products', href: '/products' },
+  { label: 'Current Page' },
+];
+
+describe('Breadcrumbs', () => {
+  it('renders all breadcrumb items', () => {
+    render(Breadcrumbs, { props: { items: testItems } });
+    expect(screen.getByText('Home')).toBeTruthy();
+    expect(screen.getByText('Products')).toBeTruthy();
+    expect(screen.getByText('Current Page')).toBeTruthy();
+  });
+
+  it('renders non-last items with href as links', () => {
+    render(Breadcrumbs, { props: { items: testItems } });
+    const home = screen.getByText('Home');
+    expect(home.closest('a')).toBeTruthy();
+    expect(home.closest('a')?.getAttribute('href')).toBe('/');
+  });
+
+  it('renders last item as a span (not a link)', () => {
+    render(Breadcrumbs, { props: { items: testItems } });
+    const current = screen.getByText('Current Page');
+    expect(current.closest('a')).toBeFalsy();
+    expect(current.closest('span')).toBeTruthy();
+  });
+
+  it('sets aria-current on the last item', () => {
+    const { container } = render(Breadcrumbs, { props: { items: testItems } });
+    const listItems = container.querySelectorAll('li');
+    const lastItem = listItems[listItems.length - 1];
+    expect(lastItem.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('does not set aria-current on non-last items', () => {
+    const { container } = render(Breadcrumbs, { props: { items: testItems } });
+    const listItems = container.querySelectorAll('li');
+    expect(listItems[0].getAttribute('aria-current')).toBeNull();
+    expect(listItems[1].getAttribute('aria-current')).toBeNull();
+  });
+
+  it('applies breadcrumbs class', () => {
+    const { container } = render(Breadcrumbs, { props: { items: testItems } });
+    expect(container.querySelector('.breadcrumbs')).toBeTruthy();
+  });
+
+  it('renders items in a ul list', () => {
+    const { container } = render(Breadcrumbs, { props: { items: testItems } });
+    const ul = container.querySelector('ul');
+    expect(ul).toBeTruthy();
+    expect(ul?.querySelectorAll('li').length).toBe(3);
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(Breadcrumbs, {
+      props: { items: testItems, className: 'custom' },
+    });
+    expect(container.querySelector('.custom')).toBeTruthy();
+  });
+
+  it('handles single item', () => {
+    render(Breadcrumbs, { props: { items: [{ label: 'Home' }] } });
+    const home = screen.getByText('Home');
+    expect(home.closest('a')).toBeFalsy();
+  });
+
+  it('renders last item with href as span not link', () => {
+    const items = [
+      { label: 'Home', href: '/' },
+      { label: 'Last', href: '/last' },
+    ];
+    render(Breadcrumbs, { props: { items } });
+    const last = screen.getByText('Last');
+    expect(last.closest('a')).toBeFalsy();
+    expect(last.closest('span')).toBeTruthy();
+  });
+});

--- a/packages/vue/src/__tests__/navigation/menu.test.ts
+++ b/packages/vue/src/__tests__/navigation/menu.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/vue';
+import { Menu } from '../../components/navigation';
+
+const testItems = [
+  { name: 'home', label: 'Home', href: '/' },
+  { name: 'about', label: 'About', href: '/about' },
+  { name: 'contact', label: 'Contact', disabled: true },
+];
+
+const nestedItems = [
+  { name: 'home', label: 'Home', href: '/' },
+  {
+    name: 'products',
+    label: 'Products',
+    children: [
+      { name: 'shirts', label: 'Shirts', href: '/products/shirts' },
+      { name: 'pants', label: 'Pants', href: '/products/pants' },
+    ],
+  },
+];
+
+describe('Menu', () => {
+  it('renders all menu items', () => {
+    render(Menu, { props: { items: testItems } });
+    expect(screen.getByText('Home')).toBeTruthy();
+    expect(screen.getByText('About')).toBeTruthy();
+    expect(screen.getByText('Contact')).toBeTruthy();
+  });
+
+  it('renders items with href as links', () => {
+    render(Menu, { props: { items: testItems } });
+    const homeLink = screen.getByText('Home');
+    expect(homeLink.tagName).toBe('A');
+    expect(homeLink.getAttribute('href')).toBe('/');
+  });
+
+  it('renders items without href as buttons', () => {
+    render(Menu, { props: { items: testItems } });
+    const contact = screen.getByText('Contact');
+    expect(contact.tagName).toBe('BUTTON');
+  });
+
+  it('has menubar role on container', () => {
+    const { container } = render(Menu, { props: { items: testItems } });
+    expect(container.querySelector('[role="menubar"]')).toBeTruthy();
+  });
+
+  it('has menuitem role on items', () => {
+    const { container } = render(Menu, { props: { items: testItems } });
+    const menuItems = container.querySelectorAll('[role="menuitem"]');
+    expect(menuItems.length).toBe(3);
+  });
+
+  it('applies horizontal class', () => {
+    const { container } = render(Menu, { props: { items: testItems, horizontal: true } });
+    expect(container.querySelector('.menu-horizontal')).toBeTruthy();
+  });
+
+  it('applies size class', () => {
+    const { container } = render(Menu, { props: { items: testItems, size: 'lg' } });
+    expect(container.querySelector('.menu-lg')).toBeTruthy();
+  });
+
+  it('sets aria-orientation to horizontal', () => {
+    const { container } = render(Menu, { props: { items: testItems, horizontal: true } });
+    const menubar = container.querySelector('[role="menubar"]');
+    expect(menubar?.getAttribute('aria-orientation')).toBe('horizontal');
+  });
+
+  it('sets aria-orientation to vertical by default', () => {
+    const { container } = render(Menu, { props: { items: testItems } });
+    const menubar = container.querySelector('[role="menubar"]');
+    expect(menubar?.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  it('disables items with disabled prop', () => {
+    render(Menu, { props: { items: testItems } });
+    const contact = screen.getByText('Contact');
+    expect(contact.getAttribute('disabled')).not.toBeNull();
+    expect(contact.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('marks active item with aria-current', () => {
+    const items = [{ name: 'home', label: 'Home', href: '/', active: true }];
+    render(Menu, { props: { items } });
+    const home = screen.getByText('Home');
+    expect(home.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('emits select event on item click', async () => {
+    const { emitted } = render(Menu, { props: { items: testItems } });
+    const home = screen.getByText('Home');
+    await fireEvent.click(home);
+    expect(emitted().select).toBeTruthy();
+    expect(emitted().select[0]).toEqual(['home']);
+  });
+
+  it('does not emit select for disabled items', async () => {
+    const { emitted } = render(Menu, { props: { items: testItems } });
+    const contact = screen.getByText('Contact');
+    await fireEvent.click(contact);
+    expect(emitted().select).toBeFalsy();
+  });
+
+  it('renders nested items with submenu', () => {
+    render(Menu, { props: { items: nestedItems } });
+    expect(screen.getByText('Products')).toBeTruthy();
+    expect(screen.getByText('Shirts')).toBeTruthy();
+    expect(screen.getByText('Pants')).toBeTruthy();
+  });
+
+  it('renders submenu as nested menu role', () => {
+    const { container } = render(Menu, { props: { items: nestedItems } });
+    const submenus = container.querySelectorAll('[role="menu"]');
+    expect(submenus.length).toBe(1);
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(Menu, { props: { items: testItems, className: 'custom-class' } });
+    expect(container.querySelector('.custom-class')).toBeTruthy();
+  });
+});

--- a/packages/vue/src/__tests__/navigation/menu.test.ts
+++ b/packages/vue/src/__tests__/navigation/menu.test.ts
@@ -41,15 +41,10 @@ describe('Menu', () => {
     expect(contact.tagName).toBe('BUTTON');
   });
 
-  it('has menubar role on container', () => {
+  it('renders as a ul with menu class', () => {
     const { container } = render(Menu, { props: { items: testItems } });
-    expect(container.querySelector('[role="menubar"]')).toBeTruthy();
-  });
-
-  it('has menuitem role on items', () => {
-    const { container } = render(Menu, { props: { items: testItems } });
-    const menuItems = container.querySelectorAll('[role="menuitem"]');
-    expect(menuItems.length).toBe(3);
+    const ul = container.querySelector('ul.menu');
+    expect(ul).toBeTruthy();
   });
 
   it('applies horizontal class', () => {
@@ -62,23 +57,10 @@ describe('Menu', () => {
     expect(container.querySelector('.menu-lg')).toBeTruthy();
   });
 
-  it('sets aria-orientation to horizontal', () => {
-    const { container } = render(Menu, { props: { items: testItems, horizontal: true } });
-    const menubar = container.querySelector('[role="menubar"]');
-    expect(menubar?.getAttribute('aria-orientation')).toBe('horizontal');
-  });
-
-  it('sets aria-orientation to vertical by default', () => {
-    const { container } = render(Menu, { props: { items: testItems } });
-    const menubar = container.querySelector('[role="menubar"]');
-    expect(menubar?.getAttribute('aria-orientation')).toBe('vertical');
-  });
-
   it('disables items with disabled prop', () => {
     render(Menu, { props: { items: testItems } });
     const contact = screen.getByText('Contact');
     expect(contact.getAttribute('disabled')).not.toBeNull();
-    expect(contact.getAttribute('aria-disabled')).toBe('true');
   });
 
   it('marks active item with aria-current', () => {
@@ -110,10 +92,10 @@ describe('Menu', () => {
     expect(screen.getByText('Pants')).toBeTruthy();
   });
 
-  it('renders submenu as nested menu role', () => {
+  it('renders submenu as nested ul', () => {
     const { container } = render(Menu, { props: { items: nestedItems } });
-    const submenus = container.querySelectorAll('[role="menu"]');
-    expect(submenus.length).toBe(1);
+    const nestedUls = container.querySelectorAll('details ul');
+    expect(nestedUls.length).toBe(1);
   });
 
   it('applies custom className', () => {

--- a/packages/vue/src/__tests__/navigation/navbar.test.ts
+++ b/packages/vue/src/__tests__/navigation/navbar.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/vue';
+import { Navbar } from '../../components/navigation';
+
+describe('Navbar', () => {
+  it('renders with navbar class', () => {
+    const { container } = render(Navbar);
+    expect(container.querySelector('.navbar')).toBeTruthy();
+  });
+
+  it('has navigation role', () => {
+    const { container } = render(Navbar);
+    expect(container.querySelector('[role="navigation"]')).toBeTruthy();
+  });
+
+  it('has aria-label', () => {
+    const { container } = render(Navbar);
+    const nav = container.querySelector('nav');
+    expect(nav?.getAttribute('aria-label')).toBe('Main navigation');
+  });
+
+  it('renders start slot', () => {
+    render(Navbar, {
+      slots: { start: '<span>Logo</span>' },
+    });
+    expect(screen.getByText('Logo')).toBeTruthy();
+  });
+
+  it('renders center slot', () => {
+    render(Navbar, {
+      slots: { center: '<span>Title</span>' },
+    });
+    expect(screen.getByText('Title')).toBeTruthy();
+  });
+
+  it('renders end slot', () => {
+    render(Navbar, {
+      slots: { end: '<span>Actions</span>' },
+    });
+    expect(screen.getByText('Actions')).toBeTruthy();
+  });
+
+  it('renders start slot in navbar-start', () => {
+    const { container } = render(Navbar, {
+      slots: { start: '<span>Logo</span>' },
+    });
+    expect(container.querySelector('.navbar-start')).toBeTruthy();
+  });
+
+  it('renders center slot in navbar-center', () => {
+    const { container } = render(Navbar, {
+      slots: { center: '<span>Title</span>' },
+    });
+    expect(container.querySelector('.navbar-center')).toBeTruthy();
+  });
+
+  it('renders end slot in navbar-end', () => {
+    const { container } = render(Navbar, {
+      slots: { end: '<span>Actions</span>' },
+    });
+    expect(container.querySelector('.navbar-end')).toBeTruthy();
+  });
+
+  it('applies color classes', () => {
+    const { container } = render(Navbar, { props: { color: 'primary' } });
+    expect(container.querySelector('.bg-primary')).toBeTruthy();
+    expect(container.querySelector('.text-primary-content')).toBeTruthy();
+  });
+
+  it('applies glass class', () => {
+    const { container } = render(Navbar, { props: { glass: true } });
+    expect(container.querySelector('.glass')).toBeTruthy();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(Navbar, { props: { className: 'custom-nav' } });
+    expect(container.querySelector('.custom-nav')).toBeTruthy();
+  });
+
+  it('renders default slot content', () => {
+    render(Navbar, {
+      slots: { default: '<span>Custom Content</span>' },
+    });
+    expect(screen.getByText('Custom Content')).toBeTruthy();
+  });
+
+  it('does not render navbar-start when slot is empty', () => {
+    const { container } = render(Navbar, {
+      slots: { end: '<span>Only End</span>' },
+    });
+    expect(container.querySelector('.navbar-start')).toBeFalsy();
+  });
+});

--- a/packages/vue/src/__tests__/navigation/pagination.test.ts
+++ b/packages/vue/src/__tests__/navigation/pagination.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/vue';
+import { Pagination } from '../../components/navigation';
+
+describe('Pagination', () => {
+  it('renders page buttons', () => {
+    render(Pagination, { props: { currentPage: 1, totalPages: 5 } });
+    expect(screen.getByText('1')).toBeTruthy();
+    expect(screen.getByText('5')).toBeTruthy();
+  });
+
+  it('marks current page as active', () => {
+    render(Pagination, { props: { currentPage: 3, totalPages: 5 } });
+    const page3 = screen.getByText('3');
+    expect(page3.classList.contains('btn-active')).toBe(true);
+  });
+
+  it('sets aria-current on active page', () => {
+    render(Pagination, { props: { currentPage: 2, totalPages: 5 } });
+    const page2 = screen.getByText('2');
+    expect(page2.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('disables previous button on first page', () => {
+    render(Pagination, { props: { currentPage: 1, totalPages: 5 } });
+    const prev = screen.getByLabelText('Previous page');
+    expect((prev as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('disables next button on last page', () => {
+    render(Pagination, { props: { currentPage: 5, totalPages: 5 } });
+    const next = screen.getByLabelText('Next page');
+    expect((next as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('emits update:currentPage on page click', async () => {
+    const { emitted } = render(Pagination, { props: { currentPage: 1, totalPages: 5 } });
+    const page2 = screen.getByText('2');
+    await fireEvent.click(page2);
+    expect(emitted()['update:currentPage']).toBeTruthy();
+    expect(emitted()['update:currentPage'][0]).toEqual([2]);
+  });
+
+  it('emits update:currentPage on next click', async () => {
+    const { emitted } = render(Pagination, { props: { currentPage: 2, totalPages: 5 } });
+    const next = screen.getByLabelText('Next page');
+    await fireEvent.click(next);
+    expect(emitted()['update:currentPage'][0]).toEqual([3]);
+  });
+
+  it('emits update:currentPage on previous click', async () => {
+    const { emitted } = render(Pagination, { props: { currentPage: 3, totalPages: 5 } });
+    const prev = screen.getByLabelText('Previous page');
+    await fireEvent.click(prev);
+    expect(emitted()['update:currentPage'][0]).toEqual([2]);
+  });
+
+  it('does not emit when clicking current page', async () => {
+    const { emitted } = render(Pagination, { props: { currentPage: 1, totalPages: 5 } });
+    const page1 = screen.getByText('1');
+    await fireEvent.click(page1);
+    expect(emitted()['update:currentPage']).toBeFalsy();
+  });
+
+  it('shows ellipsis for many pages', () => {
+    render(Pagination, { props: { currentPage: 5, totalPages: 10 } });
+    const ellipses = screen.getAllByText('…');
+    expect(ellipses.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('has navigation role and aria-label', () => {
+    const { container } = render(Pagination, { props: { currentPage: 1, totalPages: 5 } });
+    const nav = container.querySelector('[role="navigation"]');
+    expect(nav).toBeTruthy();
+    expect(nav?.getAttribute('aria-label')).toBe('Pagination');
+  });
+
+  it('does not render page buttons for single page', () => {
+    const { container } = render(Pagination, { props: { currentPage: 1, totalPages: 1 } });
+    const pageButtons = container.querySelectorAll('.btn-active');
+    expect(pageButtons.length).toBe(0);
+  });
+
+  it('applies size class to buttons', () => {
+    const { container } = render(Pagination, {
+      props: { currentPage: 1, totalPages: 5, size: 'sm' },
+    });
+    expect(container.querySelector('.btn-sm')).toBeTruthy();
+  });
+});

--- a/packages/vue/src/__tests__/navigation/sidebar.test.ts
+++ b/packages/vue/src/__tests__/navigation/sidebar.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/vue';
+import { Sidebar } from '../../components/navigation';
+
+describe('Sidebar', () => {
+  it('renders with drawer class', () => {
+    const { container } = render(Sidebar);
+    expect(container.querySelector('.drawer')).toBeTruthy();
+  });
+
+  it('renders default slot as main content', () => {
+    render(Sidebar, {
+      slots: { default: '<p>Main Content</p>' },
+    });
+    expect(screen.getByText('Main Content')).toBeTruthy();
+  });
+
+  it('renders sidebar slot', () => {
+    render(Sidebar, {
+      slots: { sidebar: '<p>Sidebar Content</p>' },
+    });
+    expect(screen.getByText('Sidebar Content')).toBeTruthy();
+  });
+
+  it('places main content in drawer-content', () => {
+    const { container } = render(Sidebar, {
+      slots: { default: '<p>Main</p>' },
+    });
+    const drawerContent = container.querySelector('.drawer-content');
+    expect(drawerContent?.textContent).toContain('Main');
+  });
+
+  it('applies drawer-end class for right side', () => {
+    const { container } = render(Sidebar, { props: { side: 'right' } });
+    expect(container.querySelector('.drawer-end')).toBeTruthy();
+  });
+
+  it('applies lg:drawer-open when responsive', () => {
+    const { container } = render(Sidebar, { props: { responsive: true } });
+    const drawer = container.querySelector('.drawer');
+    expect(drawer?.classList.contains('lg:drawer-open')).toBe(true);
+  });
+
+  it('does not apply lg:drawer-open when not responsive', () => {
+    const { container } = render(Sidebar, { props: { responsive: false } });
+    const drawer = container.querySelector('.drawer');
+    expect(drawer?.classList.contains('lg:drawer-open')).toBe(false);
+  });
+
+  it('has navigation role on sidebar aside', () => {
+    const { container } = render(Sidebar);
+    const aside = container.querySelector('aside[role="navigation"]');
+    expect(aside).toBeTruthy();
+  });
+
+  it('has aria-label on sidebar', () => {
+    const { container } = render(Sidebar, { props: { ariaLabel: 'Site navigation' } });
+    const aside = container.querySelector('aside');
+    expect(aside?.getAttribute('aria-label')).toBe('Site navigation');
+  });
+
+  it('uses default aria-label', () => {
+    const { container } = render(Sidebar);
+    const aside = container.querySelector('aside');
+    expect(aside?.getAttribute('aria-label')).toBe('Sidebar navigation');
+  });
+
+  it('has drawer-toggle checkbox', () => {
+    const { container } = render(Sidebar);
+    const checkbox = container.querySelector('.drawer-toggle');
+    expect(checkbox).toBeTruthy();
+    expect(checkbox?.getAttribute('type')).toBe('checkbox');
+  });
+
+  it('has drawer-overlay label', () => {
+    const { container } = render(Sidebar);
+    const overlay = container.querySelector('.drawer-overlay');
+    expect(overlay).toBeTruthy();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(Sidebar, { props: { className: 'custom-sidebar' } });
+    expect(container.querySelector('.custom-sidebar')).toBeTruthy();
+  });
+});

--- a/packages/vue/src/__tests__/navigation/spotlightsearch.test.ts
+++ b/packages/vue/src/__tests__/navigation/spotlightsearch.test.ts
@@ -120,8 +120,9 @@ describe('SpotlightSearch', () => {
     await waitForDialog();
     const homeItem = screen.getByText('Go to Home');
     await fireEvent.click(homeItem.closest('[role="option"]')!);
-    expect(emitted().select).toBeTruthy();
-    expect(emitted().select[0][0]).toEqual(testItems[0]);
+    const selectEvents = emitted().select as Array<[(typeof testItems)[0]]>;
+    expect(selectEvents).toBeTruthy();
+    expect(selectEvents[0][0]).toEqual(testItems[0]);
   });
 
   it('has combobox role on input', async () => {

--- a/packages/vue/src/__tests__/navigation/spotlightsearch.test.ts
+++ b/packages/vue/src/__tests__/navigation/spotlightsearch.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/vue';
+import { nextTick } from 'vue';
+import { SpotlightSearch } from '../../components/navigation';
+
+// Mock HTMLDialogElement methods
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
+
+const testItems = [
+  { id: 'home', label: 'Go to Home', description: 'Navigate to the home page' },
+  { id: 'settings', label: 'Open Settings', description: 'Manage your preferences' },
+  { id: 'profile', label: 'View Profile', description: 'See your profile', group: 'Account' },
+  { id: 'logout', label: 'Log Out', group: 'Account' },
+  { id: 'disabled', label: 'Disabled Action', disabled: true },
+];
+
+// SpotlightSearch uses Teleport to body, so we must query document.body
+function queryBody(selector: string) {
+  return document.body.querySelector(selector);
+}
+
+function queryAllBody(selector: string) {
+  return document.body.querySelectorAll(selector);
+}
+
+/** Wait for Vue reactivity + post-flush dialog updates. */
+async function waitForDialog() {
+  await nextTick();
+  await nextTick();
+}
+
+describe('SpotlightSearch', () => {
+  it('renders dialog element', () => {
+    render(SpotlightSearch, { props: { items: testItems } });
+    expect(queryBody('dialog')).toBeTruthy();
+  });
+
+  it('shows modal when open is true', async () => {
+    render(SpotlightSearch, {
+      props: { items: testItems, open: true },
+      global: { stubs: { teleport: true } },
+    });
+    await waitForDialog();
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+  });
+
+  it('renders search input', async () => {
+    render(SpotlightSearch, { props: { items: testItems, open: true } });
+    await waitForDialog();
+    const input = queryBody('input[type="text"]');
+    expect(input).toBeTruthy();
+  });
+
+  it('uses custom placeholder', async () => {
+    render(SpotlightSearch, {
+      props: { items: testItems, open: true, placeholder: 'Type a command…' },
+    });
+    await waitForDialog();
+    const input = queryBody('input[type="text"]') as HTMLInputElement;
+    expect(input.placeholder).toBe('Type a command…');
+  });
+
+  it('displays all non-disabled items when no query', async () => {
+    render(SpotlightSearch, { props: { items: testItems, open: true } });
+    await waitForDialog();
+    expect(screen.getByText('Go to Home')).toBeTruthy();
+    expect(screen.getByText('Open Settings')).toBeTruthy();
+    expect(screen.getByText('View Profile')).toBeTruthy();
+    expect(screen.getByText('Log Out')).toBeTruthy();
+  });
+
+  it('filters items based on query', async () => {
+    render(SpotlightSearch, { props: { items: testItems, open: true } });
+    await waitForDialog();
+    const input = queryBody('input[type="text"]') as HTMLInputElement;
+    await fireEvent.update(input, 'settings');
+    await nextTick();
+    expect(screen.getByText('Open Settings')).toBeTruthy();
+    expect(screen.queryByText('Go to Home')).toBeFalsy();
+  });
+
+  it('shows no results message when nothing matches', async () => {
+    render(SpotlightSearch, { props: { items: testItems, open: true } });
+    await waitForDialog();
+    const input = queryBody('input[type="text"]') as HTMLInputElement;
+    await fireEvent.update(input, 'xyznonexistent');
+    await nextTick();
+    expect(screen.getByText('No results found.')).toBeTruthy();
+  });
+
+  it('excludes disabled items from results', async () => {
+    render(SpotlightSearch, { props: { items: testItems, open: true } });
+    await waitForDialog();
+    expect(screen.queryByText('Disabled Action')).toBeFalsy();
+  });
+
+  it('displays group headers', async () => {
+    render(SpotlightSearch, { props: { items: testItems, open: true } });
+    await waitForDialog();
+    expect(screen.getByText('Account')).toBeTruthy();
+  });
+
+  it('renders item descriptions', async () => {
+    render(SpotlightSearch, { props: { items: testItems, open: true } });
+    await waitForDialog();
+    expect(screen.getByText('Navigate to the home page')).toBeTruthy();
+  });
+
+  it('emits select when item is clicked', async () => {
+    const { emitted } = render(SpotlightSearch, {
+      props: { items: testItems, open: true },
+    });
+    await waitForDialog();
+    const homeItem = screen.getByText('Go to Home');
+    await fireEvent.click(homeItem.closest('[role="option"]')!);
+    expect(emitted().select).toBeTruthy();
+    expect(emitted().select[0][0]).toEqual(testItems[0]);
+  });
+
+  it('has combobox role on input', async () => {
+    render(SpotlightSearch, { props: { items: testItems, open: true } });
+    await waitForDialog();
+    expect(queryBody('[role="combobox"]')).toBeTruthy();
+  });
+
+  it('has listbox role on results', async () => {
+    render(SpotlightSearch, { props: { items: testItems, open: true } });
+    await waitForDialog();
+    expect(queryBody('[role="listbox"]')).toBeTruthy();
+  });
+
+  it('has option role on items', async () => {
+    render(SpotlightSearch, { props: { items: testItems, open: true } });
+    await waitForDialog();
+    const options = queryAllBody('[role="option"]');
+    expect(options.length).toBe(4); // 4 non-disabled items
+  });
+
+  it('highlights first item by default', async () => {
+    render(SpotlightSearch, { props: { items: testItems, open: true } });
+    await waitForDialog();
+    const options = queryAllBody('[role="option"]');
+    expect(options[0].getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('has aria-modal on dialog', () => {
+    render(SpotlightSearch, { props: { items: testItems } });
+    const dialog = queryBody('dialog');
+    expect(dialog?.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('closes dialog on Escape keydown', async () => {
+    const { emitted } = render(SpotlightSearch, {
+      props: { items: testItems, open: true },
+    });
+    await waitForDialog();
+    const dialog = queryBody('dialog') as HTMLDialogElement;
+    await fireEvent.keyDown(dialog, { key: 'Escape' });
+    expect(emitted()['update:open']).toBeTruthy();
+    expect(emitted()['update:open'][0]).toEqual([false]);
+  });
+});

--- a/packages/vue/src/__tests__/navigation/steps.test.ts
+++ b/packages/vue/src/__tests__/navigation/steps.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/vue';
+import { Steps } from '../../components/navigation';
+
+const testSteps = [
+  { label: 'Register' },
+  { label: 'Choose Plan' },
+  { label: 'Payment' },
+  { label: 'Complete' },
+];
+
+describe('Steps', () => {
+  it('renders all step labels', () => {
+    render(Steps, { props: { steps: testSteps } });
+    expect(screen.getByText('Register')).toBeTruthy();
+    expect(screen.getByText('Choose Plan')).toBeTruthy();
+    expect(screen.getByText('Payment')).toBeTruthy();
+    expect(screen.getByText('Complete')).toBeTruthy();
+  });
+
+  it('applies step-primary to completed steps', () => {
+    const { container } = render(Steps, {
+      props: { steps: testSteps, currentStep: 1 },
+    });
+    const stepEls = container.querySelectorAll('.step');
+    expect(stepEls[0].classList.contains('step-primary')).toBe(true);
+    expect(stepEls[1].classList.contains('step-primary')).toBe(true);
+    expect(stepEls[2].classList.contains('step-primary')).toBe(false);
+  });
+
+  it('applies default color (primary) to completed steps', () => {
+    const { container } = render(Steps, {
+      props: { steps: testSteps, currentStep: 0 },
+    });
+    const stepEls = container.querySelectorAll('.step');
+    expect(stepEls[0].classList.contains('step-primary')).toBe(true);
+    expect(stepEls[1].classList.contains('step-primary')).toBe(false);
+  });
+
+  it('applies custom color to completed steps', () => {
+    const { container } = render(Steps, {
+      props: { steps: testSteps, currentStep: 2, color: 'success' },
+    });
+    const stepEls = container.querySelectorAll('.step');
+    expect(stepEls[0].classList.contains('step-success')).toBe(true);
+    expect(stepEls[2].classList.contains('step-success')).toBe(true);
+    expect(stepEls[3].classList.contains('step-success')).toBe(false);
+  });
+
+  it('supports per-step color override', () => {
+    const steps = [{ label: 'Step 1', color: 'error' as const }, { label: 'Step 2' }];
+    const { container } = render(Steps, {
+      props: { steps, currentStep: 1 },
+    });
+    const stepEls = container.querySelectorAll('.step');
+    expect(stepEls[0].classList.contains('step-error')).toBe(true);
+    expect(stepEls[1].classList.contains('step-primary')).toBe(true);
+  });
+
+  it('applies vertical class', () => {
+    const { container } = render(Steps, {
+      props: { steps: testSteps, vertical: true },
+    });
+    expect(container.querySelector('.steps-vertical')).toBeTruthy();
+  });
+
+  it('has list role', () => {
+    const { container } = render(Steps, { props: { steps: testSteps } });
+    expect(container.querySelector('[role="list"]')).toBeTruthy();
+  });
+
+  it('has listitem role on each step', () => {
+    const { container } = render(Steps, { props: { steps: testSteps } });
+    const items = container.querySelectorAll('[role="listitem"]');
+    expect(items.length).toBe(4);
+  });
+
+  it('sets aria-current on active step', () => {
+    const { container } = render(Steps, {
+      props: { steps: testSteps, currentStep: 2 },
+    });
+    const items = container.querySelectorAll('[role="listitem"]');
+    expect(items[2].getAttribute('aria-current')).toBe('step');
+    expect(items[0].getAttribute('aria-current')).toBeNull();
+    expect(items[3].getAttribute('aria-current')).toBeNull();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(Steps, {
+      props: { steps: testSteps, className: 'custom-steps' },
+    });
+    expect(container.querySelector('.custom-steps')).toBeTruthy();
+  });
+});

--- a/packages/vue/src/components/navigation/Breadcrumbs/Breadcrumbs.vue
+++ b/packages/vue/src/components/navigation/Breadcrumbs/Breadcrumbs.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+/** @module Breadcrumbs */
+import { cn } from '@artisanpack-ui/tokens';
+import type { BreadcrumbsProps } from './types';
+
+const props = defineProps<BreadcrumbsProps>();
+</script>
+
+<template>
+  <nav :class="cn('breadcrumbs text-sm', props.className)" aria-label="Breadcrumb">
+    <ul>
+      <li
+        v-for="(item, index) in items"
+        :key="index"
+        :aria-current="index === items.length - 1 ? 'page' : undefined"
+      >
+        <a v-if="item.href && index !== items.length - 1" :href="item.href">
+          <slot name="item" :item="item" :index="index" :is-last="false">
+            {{ item.label }}
+          </slot>
+        </a>
+        <span v-else>
+          <slot name="item" :item="item" :index="index" :is-last="index === items.length - 1">
+            {{ item.label }}
+          </slot>
+        </span>
+      </li>
+    </ul>
+  </nav>
+</template>

--- a/packages/vue/src/components/navigation/Breadcrumbs/types.ts
+++ b/packages/vue/src/components/navigation/Breadcrumbs/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Represents a single breadcrumb item.
+ */
+export interface BreadcrumbItem {
+  /** Display label for the breadcrumb. */
+  label: string;
+  /** Optional URL for the breadcrumb link. The last item typically has no href. */
+  href?: string;
+}
+
+/**
+ * Props for the Breadcrumbs component.
+ *
+ * A navigation breadcrumb trail with semantic markup and ARIA navigation role.
+ */
+export interface BreadcrumbsProps {
+  /** Array of breadcrumb items in order from root to current page. */
+  items: BreadcrumbItem[];
+  /** Additional CSS classes for the breadcrumb container. */
+  className?: string;
+}

--- a/packages/vue/src/components/navigation/Menu/Menu.vue
+++ b/packages/vue/src/components/navigation/Menu/Menu.vue
@@ -76,16 +76,11 @@ function handleDetailsToggle(item: { name: string }, e: Event) {
 </script>
 
 <template>
-  <ul
-    role="menubar"
-    :aria-orientation="horizontal ? 'horizontal' : 'vertical'"
-    :class="menuClasses"
-  >
-    <li v-for="item in items" :key="item.name" role="none" :class="getItemClasses(item)">
+  <ul :class="menuClasses">
+    <li v-for="item in items" :key="item.name" :class="getItemClasses(item)">
       <template v-if="item.children && item.children.length > 0">
         <details @toggle="handleDetailsToggle(item, $event)">
           <summary
-            role="menuitem"
             :class="getLinkClasses(item)"
             :aria-disabled="item.disabled || undefined"
             :aria-haspopup="'menu'"
@@ -97,17 +92,11 @@ function handleDetailsToggle(item: { name: string }, e: Event) {
               {{ item.label }}
             </slot>
           </summary>
-          <ul role="menu">
-            <li
-              v-for="child in item.children"
-              :key="child.name"
-              role="none"
-              :class="getItemClasses(child)"
-            >
+          <ul>
+            <li v-for="child in item.children" :key="child.name" :class="getItemClasses(child)">
               <a
                 v-if="child.href"
                 :href="child.href"
-                role="menuitem"
                 :class="getLinkClasses(child)"
                 :aria-disabled="child.disabled || undefined"
                 :aria-current="child.active ? 'page' : undefined"
@@ -119,10 +108,8 @@ function handleDetailsToggle(item: { name: string }, e: Event) {
               <button
                 v-else
                 type="button"
-                role="menuitem"
                 :class="getLinkClasses(child)"
                 :disabled="child.disabled"
-                :aria-disabled="child.disabled || undefined"
                 :aria-current="child.active ? 'page' : undefined"
                 @click="handleClick(child, $event)"
               >
@@ -138,7 +125,6 @@ function handleDetailsToggle(item: { name: string }, e: Event) {
         <a
           v-if="item.href"
           :href="item.href"
-          role="menuitem"
           :class="getLinkClasses(item)"
           :aria-disabled="item.disabled || undefined"
           :aria-current="item.active ? 'page' : undefined"
@@ -150,10 +136,8 @@ function handleDetailsToggle(item: { name: string }, e: Event) {
         <button
           v-else
           type="button"
-          role="menuitem"
           :class="getLinkClasses(item)"
           :disabled="item.disabled"
-          :aria-disabled="item.disabled || undefined"
           :aria-current="item.active ? 'page' : undefined"
           @click="handleClick(item, $event)"
         >

--- a/packages/vue/src/components/navigation/Menu/Menu.vue
+++ b/packages/vue/src/components/navigation/Menu/Menu.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 /** @module Menu */
-import { computed } from 'vue';
+import { computed, reactive } from 'vue';
 import { cn } from '@artisanpack-ui/tokens';
 import type { DaisyColor, Size } from '@artisanpack-ui/tokens';
 import type { MenuProps } from './types';
@@ -61,10 +61,17 @@ function handleClick(item: { name: string; disabled?: boolean }, e: Event) {
   emit('select', item.name);
 }
 
-function handleSummaryClick(item: { disabled?: boolean }, e: Event) {
+const detailsOpen = reactive(new Map<string, boolean>());
+
+function handleSummaryClick(item: { name: string; disabled?: boolean }, e: Event) {
   if (item.disabled) {
     e.preventDefault();
   }
+}
+
+function handleDetailsToggle(item: { name: string }, e: Event) {
+  const details = e.target as HTMLDetailsElement;
+  detailsOpen.set(item.name, details.open);
 }
 </script>
 
@@ -76,11 +83,13 @@ function handleSummaryClick(item: { disabled?: boolean }, e: Event) {
   >
     <li v-for="item in items" :key="item.name" role="none" :class="getItemClasses(item)">
       <template v-if="item.children && item.children.length > 0">
-        <details>
+        <details @toggle="handleDetailsToggle(item, $event)">
           <summary
             role="menuitem"
             :class="getLinkClasses(item)"
             :aria-disabled="item.disabled || undefined"
+            :aria-haspopup="'menu'"
+            :aria-expanded="detailsOpen.get(item.name) ?? false"
             :tabindex="item.disabled ? -1 : 0"
             @click="handleSummaryClick(item, $event)"
           >

--- a/packages/vue/src/components/navigation/Menu/Menu.vue
+++ b/packages/vue/src/components/navigation/Menu/Menu.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+/** @module Menu */
+import { computed } from 'vue';
+import { cn } from '@artisanpack-ui/tokens';
+import type { DaisyColor, Size } from '@artisanpack-ui/tokens';
+import type { MenuProps } from './types';
+
+const props = withDefaults(defineProps<MenuProps>(), {
+  horizontal: false,
+});
+
+const emit = defineEmits<{
+  select: [name: string];
+}>();
+
+const sizeMap: Record<Size, string> = {
+  xs: 'menu-xs',
+  sm: 'menu-sm',
+  md: 'menu-md',
+  lg: 'menu-lg',
+};
+
+const colorMap: Record<DaisyColor, string> = {
+  primary:
+    'active:bg-primary active:text-primary-content focus:bg-primary focus:text-primary-content',
+  secondary:
+    'active:bg-secondary active:text-secondary-content focus:bg-secondary focus:text-secondary-content',
+  accent: 'active:bg-accent active:text-accent-content focus:bg-accent focus:text-accent-content',
+  success:
+    'active:bg-success active:text-success-content focus:bg-success focus:text-success-content',
+  warning:
+    'active:bg-warning active:text-warning-content focus:bg-warning focus:text-warning-content',
+  error: 'active:bg-error active:text-error-content focus:bg-error focus:text-error-content',
+  info: 'active:bg-info active:text-info-content focus:bg-info focus:text-info-content',
+  neutral:
+    'active:bg-neutral active:text-neutral-content focus:bg-neutral focus:text-neutral-content',
+};
+
+const menuClasses = computed(() =>
+  cn(
+    'menu',
+    props.horizontal && 'menu-horizontal',
+    props.size && sizeMap[props.size],
+    props.className,
+  ),
+);
+
+function getItemClasses(item: { active?: boolean; disabled?: boolean }) {
+  return cn(item.active && 'active', item.disabled && 'disabled');
+}
+
+function getLinkClasses(item: { active?: boolean }) {
+  return cn(item.active && props.color && colorMap[props.color]);
+}
+
+function handleClick(item: { name: string; disabled?: boolean }, e: Event) {
+  if (item.disabled) {
+    e.preventDefault();
+    return;
+  }
+  emit('select', item.name);
+}
+
+function handleSummaryClick(item: { disabled?: boolean }, e: Event) {
+  if (item.disabled) {
+    e.preventDefault();
+  }
+}
+</script>
+
+<template>
+  <ul
+    role="menubar"
+    :aria-orientation="horizontal ? 'horizontal' : 'vertical'"
+    :class="menuClasses"
+  >
+    <li v-for="item in items" :key="item.name" role="none" :class="getItemClasses(item)">
+      <template v-if="item.children && item.children.length > 0">
+        <details>
+          <summary
+            role="menuitem"
+            :class="getLinkClasses(item)"
+            :aria-disabled="item.disabled || undefined"
+            :tabindex="item.disabled ? -1 : 0"
+            @click="handleSummaryClick(item, $event)"
+          >
+            <slot name="item" :item="item">
+              {{ item.label }}
+            </slot>
+          </summary>
+          <ul role="menu">
+            <li
+              v-for="child in item.children"
+              :key="child.name"
+              role="none"
+              :class="getItemClasses(child)"
+            >
+              <a
+                v-if="child.href"
+                :href="child.href"
+                role="menuitem"
+                :class="getLinkClasses(child)"
+                :aria-disabled="child.disabled || undefined"
+                :aria-current="child.active ? 'page' : undefined"
+                :tabindex="child.disabled ? -1 : 0"
+                @click="handleClick(child, $event)"
+              >
+                <slot name="item" :item="child">{{ child.label }}</slot>
+              </a>
+              <button
+                v-else
+                type="button"
+                role="menuitem"
+                :class="getLinkClasses(child)"
+                :disabled="child.disabled"
+                :aria-disabled="child.disabled || undefined"
+                :aria-current="child.active ? 'page' : undefined"
+                @click="handleClick(child, $event)"
+              >
+                <slot name="item" :item="child">
+                  {{ child.label }}
+                </slot>
+              </button>
+            </li>
+          </ul>
+        </details>
+      </template>
+      <template v-else>
+        <a
+          v-if="item.href"
+          :href="item.href"
+          role="menuitem"
+          :class="getLinkClasses(item)"
+          :aria-disabled="item.disabled || undefined"
+          :aria-current="item.active ? 'page' : undefined"
+          :tabindex="item.disabled ? -1 : 0"
+          @click="handleClick(item, $event)"
+        >
+          <slot name="item" :item="item">{{ item.label }}</slot>
+        </a>
+        <button
+          v-else
+          type="button"
+          role="menuitem"
+          :class="getLinkClasses(item)"
+          :disabled="item.disabled"
+          :aria-disabled="item.disabled || undefined"
+          :aria-current="item.active ? 'page' : undefined"
+          @click="handleClick(item, $event)"
+        >
+          <slot name="item" :item="item">
+            {{ item.label }}
+          </slot>
+        </button>
+      </template>
+    </li>
+  </ul>
+</template>

--- a/packages/vue/src/components/navigation/Menu/types.ts
+++ b/packages/vue/src/components/navigation/Menu/types.ts
@@ -1,0 +1,38 @@
+import type { DaisyColor, Size } from '@artisanpack-ui/tokens';
+
+/**
+ * Represents a single menu item with its label, optional children, and configuration.
+ */
+export interface MenuItem {
+  /** Unique identifier for the menu item. */
+  name: string;
+  /** Display label shown in the menu item. */
+  label: string;
+  /** Optional URL for the menu item link. */
+  href?: string;
+  /** Whether the menu item is currently active. @defaultValue `false` */
+  active?: boolean;
+  /** Whether the menu item is disabled. @defaultValue `false` */
+  disabled?: boolean;
+  /** Optional nested child items for submenu support. */
+  children?: MenuItem[];
+}
+
+/**
+ * Props for the Menu component.
+ *
+ * A vertical or horizontal menu with active state tracking,
+ * nested submenus, and full keyboard navigation.
+ */
+export interface MenuProps {
+  /** Array of menu item definitions. */
+  items: MenuItem[];
+  /** When true, renders items horizontally. @defaultValue `false` */
+  horizontal?: boolean;
+  /** DaisyUI size modifier for the menu. */
+  size?: Size;
+  /** DaisyUI color applied to active items. */
+  color?: DaisyColor;
+  /** Additional CSS classes for the menu container. */
+  className?: string;
+}

--- a/packages/vue/src/components/navigation/Navbar/Navbar.vue
+++ b/packages/vue/src/components/navigation/Navbar/Navbar.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+/** @module Navbar */
+import { computed } from 'vue';
+import { cn } from '@artisanpack-ui/tokens';
+import type { DaisyColor } from '@artisanpack-ui/tokens';
+import type { NavbarProps } from './types';
+
+const props = withDefaults(defineProps<NavbarProps>(), {
+  glass: false,
+});
+
+const colorMap: Record<DaisyColor, string> = {
+  primary: 'bg-primary text-primary-content',
+  secondary: 'bg-secondary text-secondary-content',
+  accent: 'bg-accent text-accent-content',
+  success: 'bg-success text-success-content',
+  warning: 'bg-warning text-warning-content',
+  error: 'bg-error text-error-content',
+  info: 'bg-info text-info-content',
+  neutral: 'bg-neutral text-neutral-content',
+};
+
+const navbarClasses = computed(() =>
+  cn('navbar', props.color && colorMap[props.color], props.glass && 'glass', props.className),
+);
+</script>
+
+<template>
+  <nav :class="navbarClasses" role="navigation" aria-label="Main navigation">
+    <div v-if="$slots.start" class="navbar-start">
+      <slot name="start" />
+    </div>
+    <div v-if="$slots.center" class="navbar-center">
+      <slot name="center" />
+    </div>
+    <div v-if="$slots.end" class="navbar-end">
+      <slot name="end" />
+    </div>
+    <slot />
+  </nav>
+</template>

--- a/packages/vue/src/components/navigation/Navbar/types.ts
+++ b/packages/vue/src/components/navigation/Navbar/types.ts
@@ -1,0 +1,16 @@
+import type { DaisyColor } from '@artisanpack-ui/tokens';
+
+/**
+ * Props for the Navbar component.
+ *
+ * A top navigation bar with start, center, and end slots for flexible layout.
+ * Built on DaisyUI's navbar class.
+ */
+export interface NavbarProps {
+  /** DaisyUI background color for the navbar. */
+  color?: DaisyColor;
+  /** When true, applies glass morphism styling. @defaultValue `false` */
+  glass?: boolean;
+  /** Additional CSS classes for the navbar container. */
+  className?: string;
+}

--- a/packages/vue/src/components/navigation/Pagination/Pagination.vue
+++ b/packages/vue/src/components/navigation/Pagination/Pagination.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+/** @module Pagination */
+import { computed } from 'vue';
+import { cn } from '@artisanpack-ui/tokens';
+import type { Size } from '@artisanpack-ui/tokens';
+import type { PaginationProps } from './types';
+
+const props = withDefaults(defineProps<PaginationProps>(), {
+  siblingCount: 1,
+});
+
+const emit = defineEmits<{
+  'update:currentPage': [page: number];
+}>();
+
+const sizeMap: Record<Size, string> = {
+  xs: 'btn-xs',
+  sm: 'btn-sm',
+  md: 'btn-md',
+  lg: 'btn-lg',
+};
+
+const ELLIPSIS = '…';
+
+const pages = computed(() => {
+  const total = props.totalPages;
+  const current = props.currentPage;
+  const siblings = props.siblingCount;
+
+  if (total <= 1) return [];
+
+  const range: (number | string)[] = [];
+
+  const leftSibling = Math.max(current - siblings, 2);
+  const rightSibling = Math.min(current + siblings, total - 1);
+
+  const showLeftEllipsis = leftSibling > 2;
+  const showRightEllipsis = rightSibling < total - 1;
+
+  range.push(1);
+
+  if (showLeftEllipsis) {
+    range.push(ELLIPSIS);
+  } else {
+    for (let i = 2; i < leftSibling; i++) {
+      range.push(i);
+    }
+  }
+
+  for (let i = leftSibling; i <= rightSibling; i++) {
+    range.push(i);
+  }
+
+  if (showRightEllipsis) {
+    range.push(ELLIPSIS);
+  } else {
+    for (let i = rightSibling + 1; i < total; i++) {
+      range.push(i);
+    }
+  }
+
+  range.push(total);
+
+  return range;
+});
+
+function goToPage(page: number) {
+  if (page < 1 || page > props.totalPages || page === props.currentPage) return;
+  emit('update:currentPage', page);
+}
+
+const btnClasses = computed(() => cn('join-item btn', props.size && sizeMap[props.size]));
+</script>
+
+<template>
+  <nav :class="cn('pagination', props.className)" role="navigation" aria-label="Pagination">
+    <div class="join">
+      <button
+        :class="btnClasses"
+        :disabled="currentPage <= 1"
+        aria-label="Previous page"
+        type="button"
+        @click="goToPage(currentPage - 1)"
+      >
+        «
+      </button>
+      <template v-for="(page, index) in pages" :key="typeof page === 'number' ? `page-${page}` : `gap-${index}`">
+        <button
+          v-if="typeof page === 'number'"
+          :class="cn(btnClasses, page === currentPage && 'btn-active')"
+          :aria-current="page === currentPage ? 'page' : undefined"
+          :aria-label="`Page ${page}`"
+          type="button"
+          @click="goToPage(page)"
+        >
+          {{ page }}
+        </button>
+        <button v-else :class="cn(btnClasses, 'btn-disabled')" disabled type="button">
+          {{ page }}
+        </button>
+      </template>
+      <button
+        :class="btnClasses"
+        :disabled="currentPage >= totalPages"
+        aria-label="Next page"
+        type="button"
+        @click="goToPage(currentPage + 1)"
+      >
+        »
+      </button>
+    </div>
+  </nav>
+</template>

--- a/packages/vue/src/components/navigation/Pagination/Pagination.vue
+++ b/packages/vue/src/components/navigation/Pagination/Pagination.vue
@@ -22,9 +22,14 @@ const sizeMap: Record<Size, string> = {
 
 const ELLIPSIS = '…';
 
+const normalizedTotal = computed(() => Math.max(1, props.totalPages));
+const normalizedCurrent = computed(() =>
+  Math.min(Math.max(1, props.currentPage), normalizedTotal.value),
+);
+
 const pages = computed(() => {
-  const total = Math.max(1, props.totalPages);
-  const current = Math.min(Math.max(1, props.currentPage), total);
+  const total = normalizedTotal.value;
+  const current = normalizedCurrent.value;
   const siblings = Math.max(0, props.siblingCount);
 
   if (total <= 1) return [];
@@ -65,7 +70,7 @@ const pages = computed(() => {
 });
 
 function goToPage(page: number) {
-  if (page < 1 || page > props.totalPages || page === props.currentPage) return;
+  if (page < 1 || page > normalizedTotal.value || page === normalizedCurrent.value) return;
   emit('update:currentPage', page);
 }
 
@@ -77,10 +82,10 @@ const btnClasses = computed(() => cn('join-item btn', props.size && sizeMap[prop
     <div class="join">
       <button
         :class="btnClasses"
-        :disabled="currentPage <= 1"
+        :disabled="normalizedCurrent <= 1"
         aria-label="Previous page"
         type="button"
-        @click="goToPage(currentPage - 1)"
+        @click="goToPage(normalizedCurrent - 1)"
       >
         «
       </button>
@@ -90,8 +95,8 @@ const btnClasses = computed(() => cn('join-item btn', props.size && sizeMap[prop
       >
         <button
           v-if="typeof page === 'number'"
-          :class="cn(btnClasses, page === currentPage && 'btn-active')"
-          :aria-current="page === currentPage ? 'page' : undefined"
+          :class="cn(btnClasses, page === normalizedCurrent && 'btn-active')"
+          :aria-current="page === normalizedCurrent ? 'page' : undefined"
           :aria-label="`Page ${page}`"
           type="button"
           @click="goToPage(page)"
@@ -104,10 +109,10 @@ const btnClasses = computed(() => cn('join-item btn', props.size && sizeMap[prop
       </template>
       <button
         :class="btnClasses"
-        :disabled="currentPage >= totalPages"
+        :disabled="normalizedCurrent >= normalizedTotal"
         aria-label="Next page"
         type="button"
-        @click="goToPage(currentPage + 1)"
+        @click="goToPage(normalizedCurrent + 1)"
       >
         »
       </button>

--- a/packages/vue/src/components/navigation/Pagination/Pagination.vue
+++ b/packages/vue/src/components/navigation/Pagination/Pagination.vue
@@ -23,9 +23,9 @@ const sizeMap: Record<Size, string> = {
 const ELLIPSIS = '…';
 
 const pages = computed(() => {
-  const total = props.totalPages;
-  const current = props.currentPage;
-  const siblings = props.siblingCount;
+  const total = Math.max(1, props.totalPages);
+  const current = Math.min(Math.max(1, props.currentPage), total);
+  const siblings = Math.max(0, props.siblingCount);
 
   if (total <= 1) return [];
 

--- a/packages/vue/src/components/navigation/Pagination/Pagination.vue
+++ b/packages/vue/src/components/navigation/Pagination/Pagination.vue
@@ -84,7 +84,10 @@ const btnClasses = computed(() => cn('join-item btn', props.size && sizeMap[prop
       >
         «
       </button>
-      <template v-for="(page, index) in pages" :key="typeof page === 'number' ? `page-${page}` : `gap-${index}`">
+      <template
+        v-for="(page, index) in pages"
+        :key="typeof page === 'number' ? `page-${page}` : `gap-${index}`"
+      >
         <button
           v-if="typeof page === 'number'"
           :class="cn(btnClasses, page === currentPage && 'btn-active')"

--- a/packages/vue/src/components/navigation/Pagination/types.ts
+++ b/packages/vue/src/components/navigation/Pagination/types.ts
@@ -1,0 +1,20 @@
+import type { Size } from '@artisanpack-ui/tokens';
+
+/**
+ * Props for the Pagination component.
+ *
+ * Page navigation with numbered pages, previous/next buttons,
+ * and configurable sibling page count.
+ */
+export interface PaginationProps {
+  /** Current active page number (1-based). */
+  currentPage: number;
+  /** Total number of pages. */
+  totalPages: number;
+  /** Number of sibling pages to show on each side of the current page. @defaultValue `1` */
+  siblingCount?: number;
+  /** DaisyUI size modifier for the pagination buttons. */
+  size?: Size;
+  /** Additional CSS classes for the pagination container. */
+  className?: string;
+}

--- a/packages/vue/src/components/navigation/Sidebar/Sidebar.vue
+++ b/packages/vue/src/components/navigation/Sidebar/Sidebar.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+/** @module Sidebar */
+import { computed, useId } from 'vue';
+import { cn } from '@artisanpack-ui/tokens';
+import type { SidebarProps } from './types';
+
+const props = withDefaults(defineProps<SidebarProps>(), {
+  side: 'left',
+  responsive: true,
+  ariaLabel: 'Sidebar navigation',
+});
+
+const openModel = defineModel<boolean>('open', { default: false });
+
+const autoId = useId();
+const drawerId = `sidebar-${autoId}`;
+
+const drawerClasses = computed(() =>
+  cn(
+    'drawer',
+    props.side === 'right' && 'drawer-end',
+    props.responsive && 'lg:drawer-open',
+    props.className,
+  ),
+);
+
+function handleOverlayClose() {
+  openModel.value = false;
+}
+
+function handleOverlayKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    handleOverlayClose();
+  }
+}
+</script>
+
+<template>
+  <div :class="drawerClasses">
+    <input
+      :id="drawerId"
+      type="checkbox"
+      class="drawer-toggle"
+      :checked="openModel"
+      :aria-hidden="true"
+      @change="openModel = ($event.target as HTMLInputElement).checked"
+    />
+    <div class="drawer-content">
+      <slot />
+    </div>
+    <div class="drawer-side">
+      <div
+        class="drawer-overlay"
+        aria-label="Close sidebar"
+        role="button"
+        tabindex="0"
+        @click="handleOverlayClose"
+        @keydown="handleOverlayKeydown"
+      />
+      <aside
+        :class="cn('menu bg-base-200 min-h-full w-80 p-4')"
+        :aria-label="ariaLabel"
+        role="navigation"
+      >
+        <slot name="sidebar" />
+      </aside>
+    </div>
+  </div>
+</template>

--- a/packages/vue/src/components/navigation/Sidebar/types.ts
+++ b/packages/vue/src/components/navigation/Sidebar/types.ts
@@ -1,0 +1,18 @@
+/**
+ * Props for the Sidebar component.
+ *
+ * A collapsible side navigation panel using DaisyUI's drawer pattern.
+ * Supports responsive behavior with overlay on mobile and fixed on desktop.
+ */
+export interface SidebarProps {
+  /** Whether the sidebar is open. Use with `v-model:open`. @defaultValue `false` */
+  open?: boolean;
+  /** Side the sidebar appears on. @defaultValue `'left'` */
+  side?: 'left' | 'right';
+  /** When true, sidebar is always visible on `lg` breakpoint and above. @defaultValue `true` */
+  responsive?: boolean;
+  /** Accessible label for the sidebar navigation. @defaultValue `'Sidebar navigation'` */
+  ariaLabel?: string;
+  /** Additional CSS classes for the sidebar container. */
+  className?: string;
+}

--- a/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
+++ b/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
@@ -146,7 +146,12 @@ watch(filteredItems, (items) => {
 
 watch(
   openModel,
-  async (isOpen) => {
+  async (isOpen, _oldValue, onCleanup) => {
+    let canceled = false;
+    onCleanup(() => {
+      canceled = true;
+    });
+
     if (isOpen) {
       if (typeof document !== 'undefined') {
         previousActiveElement.value = document.activeElement as HTMLElement;
@@ -154,6 +159,7 @@ watch(
       query.value = '';
       activeIndex.value = 0;
       await nextTick();
+      if (canceled) return;
       if (dialogRef.value && !dialogRef.value.open) {
         dialogRef.value.showModal();
       }

--- a/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
+++ b/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
@@ -77,6 +77,14 @@ function selectItem(item: SpotlightItem) {
 function handleKeydown(e: KeyboardEvent) {
   const items = filteredItems.value;
 
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    close();
+    return;
+  }
+
+  if (items.length === 0) return;
+
   if (e.key === 'ArrowDown') {
     e.preventDefault();
     activeIndex.value = activeIndex.value < items.length - 1 ? activeIndex.value + 1 : 0;
@@ -89,9 +97,6 @@ function handleKeydown(e: KeyboardEvent) {
     if (active) {
       selectItem(active);
     }
-  } else if (e.key === 'Escape') {
-    e.preventDefault();
-    close();
   }
 }
 

--- a/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
+++ b/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
@@ -1,0 +1,258 @@
+<script setup lang="ts">
+/** @module SpotlightSearch */
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue';
+import { cn } from '@artisanpack-ui/tokens';
+import type { SpotlightSearchProps, SpotlightItem } from './types';
+
+const props = withDefaults(defineProps<Omit<SpotlightSearchProps, 'open'>>(), {
+  placeholder: 'Search…',
+  ariaLabel: 'Search',
+});
+
+const openModel = defineModel<boolean>('open', { default: false });
+
+const emit = defineEmits<{
+  select: [item: SpotlightItem];
+}>();
+
+const autoId = useId();
+const dialogId = `spotlight-${autoId}`;
+const inputId = `spotlight-input-${autoId}`;
+const listboxId = `spotlight-listbox-${autoId}`;
+
+const dialogRef = ref<HTMLDialogElement | null>(null);
+const inputRef = ref<HTMLInputElement | null>(null);
+const previousActiveElement = ref<HTMLElement | null>(null);
+
+const query = ref('');
+const activeIndex = ref(0);
+
+const filteredItems = computed(() => {
+  const q = query.value.toLowerCase().trim();
+  if (!q) return props.items.filter((item) => !item.disabled);
+  return props.items.filter(
+    (item) =>
+      !item.disabled &&
+      (item.label.toLowerCase().includes(q) ||
+        (item.description && item.description.toLowerCase().includes(q))),
+  );
+});
+
+const groupedItems = computed(() => {
+  const groups = new Map<string, SpotlightItem[]>();
+  for (const item of filteredItems.value) {
+    const group = item.group ?? '';
+    if (!groups.has(group)) {
+      groups.set(group, []);
+    }
+    groups.get(group)!.push(item);
+  }
+  return groups;
+});
+
+const itemIndexMap = computed(() => {
+  const map = new Map<string, number>();
+  filteredItems.value.forEach((item, i) => map.set(item.id, i));
+  return map;
+});
+
+function getItemIndex(item: SpotlightItem): number {
+  return itemIndexMap.value.get(item.id) ?? -1;
+}
+
+function open() {
+  openModel.value = true;
+}
+
+function close() {
+  openModel.value = false;
+}
+
+function selectItem(item: SpotlightItem) {
+  if (item.disabled) return;
+  emit('select', item);
+  close();
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  const items = filteredItems.value;
+
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    activeIndex.value = activeIndex.value < items.length - 1 ? activeIndex.value + 1 : 0;
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    activeIndex.value = activeIndex.value > 0 ? activeIndex.value - 1 : items.length - 1;
+  } else if (e.key === 'Enter') {
+    e.preventDefault();
+    const active = items[activeIndex.value];
+    if (active) {
+      selectItem(active);
+    }
+  } else if (e.key === 'Escape') {
+    e.preventDefault();
+    close();
+  }
+}
+
+function handleGlobalKeydown(e: KeyboardEvent) {
+  if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+    e.preventDefault();
+    if (openModel.value) {
+      close();
+    } else {
+      open();
+    }
+  }
+}
+
+function handleBackdropClick(e: MouseEvent) {
+  if (e.target === dialogRef.value) {
+    close();
+  }
+}
+
+function getItemId(item: SpotlightItem) {
+  return `spotlight-item-${autoId}-${item.id}`;
+}
+
+// Reset state on query change
+watch(query, () => {
+  activeIndex.value = 0;
+});
+
+watch(
+  openModel,
+  async (isOpen) => {
+    if (isOpen) {
+      previousActiveElement.value = document.activeElement as HTMLElement;
+      query.value = '';
+      activeIndex.value = 0;
+      await nextTick();
+      if (dialogRef.value && !dialogRef.value.open) {
+        dialogRef.value.showModal();
+      }
+      inputRef.value?.focus();
+    } else {
+      dialogRef.value?.close();
+      if (previousActiveElement.value?.isConnected) {
+        previousActiveElement.value.focus();
+      }
+      previousActiveElement.value = null;
+    }
+  },
+  { immediate: true, flush: 'post' },
+);
+
+onMounted(() => {
+  document.addEventListener('keydown', handleGlobalKeydown);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', handleGlobalKeydown);
+  if (dialogRef.value?.open) {
+    dialogRef.value.close();
+  }
+});
+
+function handleCancel(_e: Event) {
+  close();
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <dialog
+      :id="dialogId"
+      ref="dialogRef"
+      class="modal"
+      :aria-label="ariaLabel"
+      aria-modal="true"
+      @click="handleBackdropClick"
+      @cancel="handleCancel"
+      @keydown="handleKeydown"
+    >
+      <div :class="cn('modal-box max-w-lg p-0', props.className)">
+        <div class="flex items-center border-b border-base-300 px-4">
+          <svg
+            class="h-5 w-5 shrink-0 text-base-content/50"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+            />
+          </svg>
+          <input
+            :id="inputId"
+            ref="inputRef"
+            v-model="query"
+            type="text"
+            :placeholder="placeholder"
+            class="input input-ghost w-full border-0 focus:outline-none"
+            role="combobox"
+            :aria-expanded="filteredItems.length > 0"
+            :aria-controls="listboxId"
+            :aria-activedescendant="
+              filteredItems[activeIndex] ? getItemId(filteredItems[activeIndex]) : undefined
+            "
+            autocomplete="off"
+          />
+          <kbd class="kbd kbd-sm">esc</kbd>
+        </div>
+
+        <ul
+          v-if="filteredItems.length > 0"
+          :id="listboxId"
+          role="listbox"
+          :aria-label="ariaLabel"
+          class="max-h-80 overflow-y-auto p-2"
+        >
+          <template v-for="[group, groupItems] in groupedItems" :key="group">
+            <li
+              v-if="group"
+              role="presentation"
+              class="px-3 py-1.5 text-xs font-semibold text-base-content/50 uppercase"
+            >
+              {{ group }}
+            </li>
+            <li
+              v-for="item in groupItems"
+              :id="getItemId(item)"
+              :key="item.id"
+              role="option"
+              :aria-selected="getItemIndex(item) === activeIndex"
+              :class="
+                cn(
+                  'cursor-pointer rounded-lg px-3 py-2',
+                  getItemIndex(item) === activeIndex && 'bg-base-200',
+                )
+              "
+              @click="selectItem(item)"
+              @mouseenter="activeIndex = getItemIndex(item)"
+            >
+              <slot name="item" :item="item" :is-active="getItemIndex(item) === activeIndex">
+                <div class="font-medium">
+                  {{ item.label }}
+                </div>
+                <div v-if="item.description" class="text-sm text-base-content/60">
+                  {{ item.description }}
+                </div>
+              </slot>
+            </li>
+          </template>
+        </ul>
+
+        <div v-else class="p-8 text-center text-base-content/50">
+          <slot name="empty"> No results found. </slot>
+        </div>
+      </div>
+    </dialog>
+  </Teleport>
+</template>

--- a/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
+++ b/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
@@ -213,6 +213,7 @@ function handleCancel(_e: Event) {
             :placeholder="placeholder"
             class="input input-ghost w-full border-0 focus:outline-none"
             role="combobox"
+            :aria-label="ariaLabel"
             :aria-expanded="filteredItems.length > 0"
             :aria-controls="listboxId"
             :aria-activedescendant="

--- a/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
+++ b/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
@@ -121,9 +121,18 @@ function getItemId(item: SpotlightItem) {
   return `spotlight-item-${autoId}-${item.id}`;
 }
 
-// Reset state on query change
+// Reset active index on query change
 watch(query, () => {
   activeIndex.value = 0;
+});
+
+// Clamp active index when filtered list shrinks
+watch(filteredItems, (items) => {
+  if (items.length === 0) {
+    activeIndex.value = 0;
+  } else if (activeIndex.value >= items.length) {
+    activeIndex.value = items.length - 1;
+  }
 });
 
 watch(

--- a/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
+++ b/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
@@ -126,6 +126,15 @@ watch(query, () => {
   activeIndex.value = 0;
 });
 
+// Scroll active item into view on index change
+watch(activeIndex, async () => {
+  await nextTick();
+  const item = filteredItems.value[activeIndex.value];
+  if (!item) return;
+  const el = document.getElementById(getItemId(item));
+  el?.scrollIntoView({ block: 'nearest' });
+});
+
 // Clamp active index when filtered list shrinks
 watch(filteredItems, (items) => {
   if (items.length === 0) {

--- a/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
+++ b/packages/vue/src/components/navigation/SpotlightSearch/SpotlightSearch.vue
@@ -130,7 +130,9 @@ watch(
   openModel,
   async (isOpen) => {
     if (isOpen) {
-      previousActiveElement.value = document.activeElement as HTMLElement;
+      if (typeof document !== 'undefined') {
+        previousActiveElement.value = document.activeElement as HTMLElement;
+      }
       query.value = '';
       activeIndex.value = 0;
       await nextTick();

--- a/packages/vue/src/components/navigation/SpotlightSearch/types.ts
+++ b/packages/vue/src/components/navigation/SpotlightSearch/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Represents a single searchable command/action in the spotlight.
+ */
+export interface SpotlightItem {
+  /** Unique identifier for the item. */
+  id: string;
+  /** Display label for the item. */
+  label: string;
+  /** Optional description shown below the label. */
+  description?: string;
+  /** Optional group name for categorization. */
+  group?: string;
+  /** Whether the item is disabled. @defaultValue `false` */
+  disabled?: boolean;
+}
+
+/**
+ * Props for the SpotlightSearch component.
+ *
+ * A command palette / search overlay triggered by Cmd+K (Mac) or Ctrl+K (Windows).
+ * Provides keyboard navigation, fuzzy filtering, and grouped results.
+ */
+export interface SpotlightSearchProps {
+  /** Whether the spotlight is open. Use with `v-model:open`. */
+  open?: boolean;
+  /** Array of searchable items. */
+  items: SpotlightItem[];
+  /** Placeholder text for the search input. @defaultValue `'Search…'` */
+  placeholder?: string;
+  /** Label for screen readers. @defaultValue `'Search'` */
+  ariaLabel?: string;
+  /** Additional CSS classes for the modal container. */
+  className?: string;
+}

--- a/packages/vue/src/components/navigation/Steps/Steps.vue
+++ b/packages/vue/src/components/navigation/Steps/Steps.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+/** @module Steps */
+import { computed } from 'vue';
+import { cn } from '@artisanpack-ui/tokens';
+import type { DaisyColor } from '@artisanpack-ui/tokens';
+import type { StepsProps } from './types';
+
+const props = withDefaults(defineProps<StepsProps>(), {
+  currentStep: 0,
+  vertical: false,
+  color: 'primary',
+});
+
+const colorMap: Record<DaisyColor, string> = {
+  primary: 'step-primary',
+  secondary: 'step-secondary',
+  accent: 'step-accent',
+  success: 'step-success',
+  warning: 'step-warning',
+  error: 'step-error',
+  info: 'step-info',
+  neutral: 'step-neutral',
+};
+
+const stepsClasses = computed(() =>
+  cn('steps', props.vertical && 'steps-vertical', props.className),
+);
+
+function getStepClasses(index: number, step: { color?: DaisyColor }) {
+  const isComplete = index <= props.currentStep;
+  const stepColor = step.color ?? props.color;
+  return cn('step', isComplete && colorMap[stepColor]);
+}
+</script>
+
+<template>
+  <ul
+    :class="stepsClasses"
+    role="list"
+    :aria-label="($attrs['aria-label'] as string) || 'Progress steps'"
+  >
+    <li
+      v-for="(step, index) in steps"
+      :key="index"
+      :class="getStepClasses(index, step)"
+      role="listitem"
+      :aria-current="index === currentStep ? 'step' : undefined"
+    >
+      <slot
+        name="step"
+        :step="step"
+        :index="index"
+        :is-active="index === currentStep"
+        :is-complete="index <= currentStep"
+      >
+        {{ step.label }}
+      </slot>
+    </li>
+  </ul>
+</template>

--- a/packages/vue/src/components/navigation/Steps/types.ts
+++ b/packages/vue/src/components/navigation/Steps/types.ts
@@ -1,0 +1,32 @@
+import type { DaisyColor } from '@artisanpack-ui/tokens';
+
+/**
+ * Represents a single step in a multi-step indicator.
+ */
+export interface StepItem {
+  /** Display label for the step. */
+  label: string;
+  /** Optional content displayed below the step label. */
+  content?: string;
+  /** DaisyUI color override for this individual step. */
+  color?: DaisyColor;
+}
+
+/**
+ * Props for the Steps component.
+ *
+ * A multi-step progress indicator with color-coded completion states
+ * and optional vertical layout.
+ */
+export interface StepsProps {
+  /** Array of step definitions. */
+  steps: StepItem[];
+  /** Index of the current active step (0-based). Steps at or before this index are marked complete. */
+  currentStep?: number;
+  /** When true, renders steps vertically. @defaultValue `false` */
+  vertical?: boolean;
+  /** Default DaisyUI color applied to completed steps. @defaultValue `'primary'` */
+  color?: DaisyColor;
+  /** Additional CSS classes for the steps container. */
+  className?: string;
+}

--- a/packages/vue/src/components/navigation/index.ts
+++ b/packages/vue/src/components/navigation/index.ts
@@ -1,2 +1,35 @@
-// navigation components
-export {};
+/**
+ * @module navigation
+ *
+ * Navigation components for the ArtisanPack UI Vue component library.
+ * Provides menus, breadcrumbs, pagination, step indicators, navbars,
+ * sidebars, and command palette search built on DaisyUI with consistent
+ * styling and accessibility.
+ *
+ * @example
+ * ```vue
+ * import { Menu, Breadcrumbs, Pagination, Navbar } from '@artisanpack-ui/vue/navigation';
+ * ```
+ */
+
+// Navigation components
+export { default as Menu } from './Menu/Menu.vue';
+export type { MenuProps, MenuItem } from './Menu/types';
+
+export { default as Breadcrumbs } from './Breadcrumbs/Breadcrumbs.vue';
+export type { BreadcrumbsProps, BreadcrumbItem } from './Breadcrumbs/types';
+
+export { default as Pagination } from './Pagination/Pagination.vue';
+export type { PaginationProps } from './Pagination/types';
+
+export { default as Steps } from './Steps/Steps.vue';
+export type { StepsProps, StepItem } from './Steps/types';
+
+export { default as Navbar } from './Navbar/Navbar.vue';
+export type { NavbarProps } from './Navbar/types';
+
+export { default as Sidebar } from './Sidebar/Sidebar.vue';
+export type { SidebarProps } from './Sidebar/types';
+
+export { default as SpotlightSearch } from './SpotlightSearch/SpotlightSearch.vue';
+export type { SpotlightSearchProps, SpotlightItem } from './SpotlightSearch/types';


### PR DESCRIPTION
## Description

Port all 7 navigation components from the Livewire UI library to Vue 3 with TypeScript, Composition API, and DaisyUI/Tailwind CSS styling.

**Closes:** #5

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #5

## Motivation and Context

The Vue library needs navigation components to build complete application interfaces with menus, breadcrumbs, pagination, and multi-step flows. These components are router-agnostic via scoped slots, support DaisyUI variants, and include full ARIA semantics and keyboard navigation.

## Changes Made

- **Menu** — Vertical/horizontal menu with active state, nested submenus via `<details>`, ARIA menubar roles, color and size variants
- **Breadcrumbs** — Semantic `<nav>` breadcrumb trail with scoped slots for custom link rendering, `aria-current="page"` on last item
- **Pagination** — Page navigation with prev/next, ellipsis for large ranges, stable composite keys, `v-model:currentPage`
- **Steps** — Multi-step progress indicator with per-step color overrides, vertical layout, `aria-current="step"`
- **Navbar** — Top navigation bar with start/center/end named slots, color and glass variants
- **Sidebar** — Collapsible drawer-based side navigation with responsive `lg:drawer-open`, keyboard-accessible overlay, left/right positioning
- **SpotlightSearch** — Cmd+K / Ctrl+K command palette with fuzzy filtering, grouped results, ARIA combobox + listbox roles, focus management via Teleport

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Node: 20+
- Vue: 3.5+

**Tests Performed:**
1. Ran full test suite (`vitest run`) — 404 tests passing
2. Manual testing in dev app at `/packages/vue/navigation-components`
3. Two rounds of CodeRabbit review with fixes applied

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked
- [x] Color contrast verified (DaisyUI theme tokens)

**Details:** All components include proper ARIA roles (menubar, menuitem, navigation, combobox, listbox, option), keyboard navigation (arrow keys, Home/End, Enter/Space, Escape), and `aria-current` for active states.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** 93 new tests across 7 test files covering rendering, ARIA attributes, keyboard interactions, event emission, slot rendering, disabled states, and variant styling.

## Documentation

- [x] Inline code documentation added

**Documentation details:** All types have JSDoc with `@defaultValue` annotations. Component modules have `@module` tags.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 7 navigation components: Breadcrumbs, Menu (nested & selectable), Navbar (slot-based layout), Pagination (page controls), Sidebar (drawer with v-model open), Steps (progress indicator), SpotlightSearch (keyboard-accessible palette).
  * Added a public navigation module exporting the new components and their prop/item types.

* **Tests**
  * Added comprehensive test suites covering rendering, accessibility/ARIA, interactions, events/emits, and styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->