### PR TITLE
Enhancement: Port utility components to Vue

### DIFF
--- a/packages/vue/src/__tests__/utility/Clipboard.test.ts
+++ b/packages/vue/src/__tests__/utility/Clipboard.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
+import { Clipboard } from '../../components/utility';
+
+describe('Clipboard', () => {
+  const writeTextMock = vi.fn().mockResolvedValue(undefined);
+  let originalClipboard: typeof navigator.clipboard;
+
+  beforeEach(() => {
+    originalClipboard = navigator.clipboard;
+    Object.assign(navigator, {
+      clipboard: { writeText: writeTextMock },
+    });
+    writeTextMock.mockClear();
+  });
+
+  afterEach(() => {
+    Object.assign(navigator, { clipboard: originalClipboard });
+    vi.restoreAllMocks();
+  });
+
+  it('renders with default label', () => {
+    render(Clipboard, { props: { text: 'hello' } });
+    expect(screen.getByText('Copy')).toBeTruthy();
+  });
+
+  it('renders with custom label', () => {
+    render(Clipboard, { props: { text: 'hello', label: 'Copy Code' } });
+    expect(screen.getByText('Copy Code')).toBeTruthy();
+  });
+
+  it('copies text to clipboard on click', async () => {
+    render(Clipboard, { props: { text: 'hello world' } });
+    await fireEvent.click(screen.getByRole('button'));
+    expect(writeTextMock).toHaveBeenCalledWith('hello world');
+  });
+
+  it('shows success label after copying', async () => {
+    render(Clipboard, { props: { text: 'hello' } });
+    await fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('Copied!')).toBeTruthy();
+  });
+
+  it('shows custom success label', async () => {
+    render(Clipboard, {
+      props: { text: 'hello', successLabel: 'Done!' },
+    });
+    await fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('Done!')).toBeTruthy();
+  });
+
+  it('resets to default label after successDuration', async () => {
+    vi.useFakeTimers();
+    render(Clipboard, { props: { text: 'hello', successDuration: 1000 } });
+
+    await fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('Copied!')).toBeTruthy();
+
+    vi.advanceTimersByTime(1000);
+    await waitFor(() => {
+      expect(screen.getByText('Copy')).toBeTruthy();
+    });
+
+    vi.useRealTimers();
+  });
+
+  it('emits copy event on success', async () => {
+    const { emitted } = render(Clipboard, { props: { text: 'hello' } });
+    await fireEvent.click(screen.getByRole('button'));
+    expect(emitted().copy).toBeTruthy();
+  });
+
+  it('emits error event on failure', async () => {
+    writeTextMock.mockRejectedValueOnce(new Error('Denied'));
+    const { emitted } = render(Clipboard, { props: { text: 'hello' } });
+    await fireEvent.click(screen.getByRole('button'));
+    expect(emitted().error).toBeTruthy();
+  });
+
+  it('has btn class', () => {
+    const { container } = render(Clipboard, { props: { text: 'hello' } });
+    expect(container.querySelector('.btn')).toBeTruthy();
+  });
+
+  it('applies color class', () => {
+    const { container } = render(Clipboard, {
+      props: { text: 'hello', color: 'primary' },
+    });
+    expect(container.querySelector('.btn-primary')).toBeTruthy();
+  });
+
+  it('applies size class', () => {
+    const { container } = render(Clipboard, {
+      props: { text: 'hello', size: 'sm' },
+    });
+    expect(container.querySelector('.btn-sm')).toBeTruthy();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(Clipboard, {
+      props: { text: 'hello', className: 'custom-btn' },
+    });
+    expect(container.querySelector('.custom-btn')).toBeTruthy();
+  });
+
+  it('has accessible aria-label', async () => {
+    render(Clipboard, { props: { text: 'hello' } });
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('aria-label')).toBe('Copy');
+
+    await fireEvent.click(button);
+    expect(button.getAttribute('aria-label')).toBe('Copied!');
+  });
+
+  it('renders custom slot content', () => {
+    render(Clipboard, {
+      props: { text: 'hello' },
+      slots: { default: '<span data-testid="custom">Custom</span>' },
+    });
+    expect(screen.getByTestId('custom')).toBeTruthy();
+  });
+
+  it('renders custom success slot content after copy', async () => {
+    render(Clipboard, {
+      props: { text: 'hello' },
+      slots: { success: '<span data-testid="success-icon">OK</span>' },
+    });
+    await fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByTestId('success-icon')).toBeTruthy();
+  });
+});

--- a/packages/vue/src/__tests__/utility/Icon.test.ts
+++ b/packages/vue/src/__tests__/utility/Icon.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/vue';
+import { Icon } from '../../components/utility';
+
+describe('Icon', () => {
+  it('renders slot content', () => {
+    render(Icon, {
+      slots: { default: '<svg data-testid="svg-icon"></svg>' },
+    });
+    expect(screen.getByTestId('svg-icon')).toBeTruthy();
+  });
+
+  it('is decorative by default (aria-hidden)', () => {
+    const { container } = render(Icon, {
+      slots: { default: '<svg></svg>' },
+    });
+    const span = container.querySelector('span');
+    expect(span?.getAttribute('aria-hidden')).toBe('true');
+    expect(span?.getAttribute('role')).toBe('presentation');
+  });
+
+  it('has role="img" and aria-label when ariaLabel is provided', () => {
+    const { container } = render(Icon, {
+      props: { ariaLabel: 'Home' },
+      slots: { default: '<svg></svg>' },
+    });
+    const span = container.querySelector('span');
+    expect(span?.getAttribute('role')).toBe('img');
+    expect(span?.getAttribute('aria-label')).toBe('Home');
+    expect(span?.hasAttribute('aria-hidden')).toBe(false);
+  });
+
+  it('applies default md size classes', () => {
+    const { container } = render(Icon, {
+      slots: { default: '<svg></svg>' },
+    });
+    const span = container.querySelector('span');
+    expect(span?.classList.contains('w-5')).toBe(true);
+    expect(span?.classList.contains('h-5')).toBe(true);
+  });
+
+  it('applies size classes', () => {
+    const sizes = [
+      { size: 'xs', w: 'w-3', h: 'h-3' },
+      { size: 'sm', w: 'w-4', h: 'h-4' },
+      { size: 'md', w: 'w-5', h: 'h-5' },
+      { size: 'lg', w: 'w-6', h: 'h-6' },
+    ] as const;
+
+    sizes.forEach(({ size, w, h }) => {
+      const { container, unmount } = render(Icon, {
+        props: { size },
+        slots: { default: '<svg></svg>' },
+      });
+      const span = container.querySelector('span');
+      expect(span?.classList.contains(w)).toBe(true);
+      expect(span?.classList.contains(h)).toBe(true);
+      unmount();
+    });
+  });
+
+  it('applies color class', () => {
+    const { container } = render(Icon, {
+      props: { color: 'primary' },
+      slots: { default: '<svg></svg>' },
+    });
+    expect(container.querySelector('.text-primary')).toBeTruthy();
+  });
+
+  it('applies all color variants', () => {
+    const colors = ['primary', 'secondary', 'accent', 'success', 'warning', 'error', 'info', 'neutral'] as const;
+    colors.forEach((color) => {
+      const { container, unmount } = render(Icon, {
+        props: { color },
+        slots: { default: '<svg></svg>' },
+      });
+      expect(container.querySelector(`.text-${color}`)).toBeTruthy();
+      unmount();
+    });
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(Icon, {
+      props: { className: 'custom-icon' },
+      slots: { default: '<svg></svg>' },
+    });
+    expect(container.querySelector('.custom-icon')).toBeTruthy();
+  });
+
+  it('renders as a span element', () => {
+    const { container } = render(Icon, {
+      slots: { default: '<svg></svg>' },
+    });
+    expect(container.querySelector('span')).toBeTruthy();
+  });
+});

--- a/packages/vue/src/__tests__/utility/Icon.test.ts
+++ b/packages/vue/src/__tests__/utility/Icon.test.ts
@@ -68,7 +68,16 @@ describe('Icon', () => {
   });
 
   it('applies all color variants', () => {
-    const colors = ['primary', 'secondary', 'accent', 'success', 'warning', 'error', 'info', 'neutral'] as const;
+    const colors = [
+      'primary',
+      'secondary',
+      'accent',
+      'success',
+      'warning',
+      'error',
+      'info',
+      'neutral',
+    ] as const;
     colors.forEach((color) => {
       const { container, unmount } = render(Icon, {
         props: { color },

--- a/packages/vue/src/__tests__/utility/Markdown.test.ts
+++ b/packages/vue/src/__tests__/utility/Markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/vue';
+import { render } from '@testing-library/vue';
 import { Markdown } from '../../components/utility';
 
 describe('Markdown', () => {

--- a/packages/vue/src/__tests__/utility/Markdown.test.ts
+++ b/packages/vue/src/__tests__/utility/Markdown.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/vue';
+import { Markdown } from '../../components/utility';
+
+describe('Markdown', () => {
+  it('renders a prose container', () => {
+    const { container } = render(Markdown, { props: { content: 'Hello' } });
+    expect(container.querySelector('.prose')).toBeTruthy();
+  });
+
+  it('renders paragraphs', () => {
+    const { container } = render(Markdown, { props: { content: 'Hello world' } });
+    expect(container.querySelector('p')?.textContent).toBe('Hello world');
+  });
+
+  it('renders headings h1 through h6', () => {
+    const content = '# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6';
+    const { container } = render(Markdown, { props: { content } });
+    expect(container.querySelector('h1')?.textContent).toBe('H1');
+    expect(container.querySelector('h2')?.textContent).toBe('H2');
+    expect(container.querySelector('h3')?.textContent).toBe('H3');
+    expect(container.querySelector('h4')?.textContent).toBe('H4');
+    expect(container.querySelector('h5')?.textContent).toBe('H5');
+    expect(container.querySelector('h6')?.textContent).toBe('H6');
+  });
+
+  it('renders bold text', () => {
+    const { container } = render(Markdown, { props: { content: '**bold**' } });
+    expect(container.querySelector('strong')?.textContent).toBe('bold');
+  });
+
+  it('renders italic text', () => {
+    const { container } = render(Markdown, { props: { content: '*italic*' } });
+    expect(container.querySelector('em')?.textContent).toBe('italic');
+  });
+
+  it('renders links', () => {
+    const { container } = render(Markdown, {
+      props: { content: '[Click here](https://example.com)' },
+    });
+    const link = container.querySelector('a');
+    expect(link?.textContent).toBe('Click here');
+    expect(link?.getAttribute('href')).toBe('https://example.com');
+  });
+
+  it('renders images', () => {
+    const { container } = render(Markdown, {
+      props: { content: '![Alt text](https://example.com/img.png)' },
+    });
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('alt')).toBe('Alt text');
+    expect(img?.getAttribute('src')).toBe('https://example.com/img.png');
+  });
+
+  it('renders unordered lists', () => {
+    const content = '- Item 1\n- Item 2\n- Item 3';
+    const { container } = render(Markdown, { props: { content } });
+    const items = container.querySelectorAll('ul > li');
+    expect(items.length).toBe(3);
+    expect(items[0].textContent).toBe('Item 1');
+  });
+
+  it('renders ordered lists', () => {
+    const content = '1. First\n2. Second\n3. Third';
+    const { container } = render(Markdown, { props: { content } });
+    const items = container.querySelectorAll('ol > li');
+    expect(items.length).toBe(3);
+    expect(items[0].textContent).toBe('First');
+  });
+
+  it('renders inline code', () => {
+    const { container } = render(Markdown, {
+      props: { content: 'Use `const` for constants' },
+    });
+    expect(container.querySelector('code')?.textContent).toBe('const');
+  });
+
+  it('renders fenced code blocks', () => {
+    const content = '```js\nconst x = 1;\n```';
+    const { container } = render(Markdown, { props: { content } });
+    expect(container.querySelector('pre code')).toBeTruthy();
+    expect(container.querySelector('pre code')?.textContent).toBe('const x = 1;');
+  });
+
+  it('escapes HTML in code blocks', () => {
+    const content = '```\n<div>test</div>\n```';
+    const { container } = render(Markdown, { props: { content } });
+    const code = container.querySelector('pre code');
+    expect(code?.textContent).toBe('<div>test</div>');
+    // Should be escaped, not rendered as a real div
+    expect(code?.innerHTML).toContain('&lt;div&gt;');
+  });
+
+  it('renders blockquotes', () => {
+    const { container } = render(Markdown, {
+      props: { content: '> This is a quote' },
+    });
+    expect(container.querySelector('blockquote')).toBeTruthy();
+    expect(container.querySelector('blockquote p')?.textContent).toBe('This is a quote');
+  });
+
+  it('renders horizontal rules', () => {
+    const { container } = render(Markdown, {
+      props: { content: 'Above\n\n---\n\nBelow' },
+    });
+    expect(container.querySelector('hr')).toBeTruthy();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(Markdown, {
+      props: { content: 'Hello', className: 'custom-prose' },
+    });
+    expect(container.querySelector('.custom-prose')).toBeTruthy();
+  });
+
+  it('escapes HTML in inline text to prevent XSS', () => {
+    const { container } = render(Markdown, {
+      props: { content: '<script>alert("xss")</script>' },
+    });
+    // Should not render as a real script element
+    expect(container.querySelector('script')).toBeFalsy();
+    expect(container.querySelector('p')?.textContent).toContain('<script>');
+  });
+
+  it('sanitizes javascript: URLs in links', () => {
+    const { container } = render(Markdown, {
+      props: { content: '[Click](javascript:alert(1))' },
+    });
+    const link = container.querySelector('a');
+    expect(link?.getAttribute('href')).toBe('#');
+  });
+
+  it('sanitizes javascript: URLs in images', () => {
+    const { container } = render(Markdown, {
+      props: { content: '![img](javascript:alert(1))' },
+    });
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('#');
+  });
+
+  it('sanitizes data: URLs in links', () => {
+    const { container } = render(Markdown, {
+      props: { content: '[Click](data:text/html,<script>alert(1)</script>)' },
+    });
+    const link = container.querySelector('a');
+    expect(link?.getAttribute('href')).toBe('#');
+  });
+
+  it('allows safe URLs', () => {
+    const { container } = render(Markdown, {
+      props: { content: '[Safe](https://example.com)' },
+    });
+    const link = container.querySelector('a');
+    expect(link?.getAttribute('href')).toBe('https://example.com');
+  });
+});

--- a/packages/vue/src/__tests__/utility/ThemeToggle.test.ts
+++ b/packages/vue/src/__tests__/utility/ThemeToggle.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
+import { defineComponent, h } from 'vue';
+import { ThemeToggle } from '../../components/utility';
+import { provideTheme } from '../../composables/use-theme';
+
+/** Wrapper that provides theme context for ThemeToggle. */
+function renderWithTheme(props: Record<string, unknown> = {}) {
+  const Wrapper = defineComponent({
+    setup() {
+      provideTheme('light');
+      return () => h(ThemeToggle, props);
+    },
+  });
+  return render(Wrapper);
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    // Mock matchMedia for jsdom
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+    localStorage.clear();
+    vi.spyOn(Storage.prototype, 'setItem');
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders a button', () => {
+    renderWithTheme();
+    expect(screen.getByRole('button')).toBeTruthy();
+  });
+
+  it('has an accessible aria-label', () => {
+    renderWithTheme();
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('aria-label')).toBeTruthy();
+  });
+
+  it('cycles through light → dark → system on click', async () => {
+    renderWithTheme();
+    const button = screen.getByRole('button');
+
+    // Initially light — label says "Switch to dark mode"
+    expect(button.getAttribute('aria-label')).toBe('Switch to dark mode');
+
+    await fireEvent.click(button);
+    expect(button.getAttribute('aria-label')).toBe('Switch to system mode');
+
+    await fireEvent.click(button);
+    expect(button.getAttribute('aria-label')).toBe('Switch to light mode');
+  });
+
+  it('applies custom className', () => {
+    const { container } = renderWithTheme({ className: 'custom-toggle' });
+    expect(container.querySelector('.custom-toggle')).toBeTruthy();
+  });
+
+  it('applies size classes', () => {
+    const { container } = renderWithTheme({ size: 'sm' });
+    expect(container.querySelector('.btn-sm')).toBeTruthy();
+  });
+
+  it('persists preference to localStorage', async () => {
+    renderWithTheme({ persist: true, storageKey: 'test-theme' });
+    const button = screen.getByRole('button');
+
+    await fireEvent.click(button);
+    expect(localStorage.setItem).toHaveBeenCalledWith('test-theme', 'dark');
+  });
+
+  it('restores preference from localStorage on mount', async () => {
+    vi.mocked(localStorage.getItem).mockReturnValue('dark');
+    renderWithTheme({ persist: true, storageKey: 'test-theme' });
+
+    const button = screen.getByRole('button');
+    // After onMounted restores 'dark', label should say "Switch to system mode"
+    await waitFor(() => {
+      expect(button.getAttribute('aria-label')).toBe('Switch to system mode');
+    });
+  });
+
+  it('renders SVG icons inside the button', () => {
+    const { container } = renderWithTheme();
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it('applies btn-ghost class', () => {
+    const { container } = renderWithTheme();
+    expect(container.querySelector('.btn-ghost')).toBeTruthy();
+  });
+});

--- a/packages/vue/src/__tests__/utility/Tooltip.test.ts
+++ b/packages/vue/src/__tests__/utility/Tooltip.test.ts
@@ -56,7 +56,16 @@ describe('Tooltip', () => {
   });
 
   it('applies all color variants', () => {
-    const colors = ['primary', 'secondary', 'accent', 'success', 'warning', 'error', 'info', 'neutral'] as const;
+    const colors = [
+      'primary',
+      'secondary',
+      'accent',
+      'success',
+      'warning',
+      'error',
+      'info',
+      'neutral',
+    ] as const;
     colors.forEach((color) => {
       const { container, unmount } = render(Tooltip, {
         props: { text: 'Tip', color },

--- a/packages/vue/src/__tests__/utility/Tooltip.test.ts
+++ b/packages/vue/src/__tests__/utility/Tooltip.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/vue';
+import { Tooltip } from '../../components/utility';
+
+describe('Tooltip', () => {
+  it('renders slot content', () => {
+    render(Tooltip, {
+      props: { text: 'Tooltip text' },
+      slots: { default: '<button>Hover me</button>' },
+    });
+    expect(screen.getByText('Hover me')).toBeTruthy();
+  });
+
+  it('sets data-tip attribute with tooltip text', () => {
+    const { container } = render(Tooltip, {
+      props: { text: 'Helpful tip' },
+      slots: { default: '<span>Trigger</span>' },
+    });
+    expect(container.querySelector('[data-tip="Helpful tip"]')).toBeTruthy();
+  });
+
+  it('has tooltip class', () => {
+    const { container } = render(Tooltip, {
+      props: { text: 'Tip' },
+      slots: { default: '<span>Trigger</span>' },
+    });
+    expect(container.querySelector('.tooltip')).toBeTruthy();
+  });
+
+  it('applies default top position', () => {
+    const { container } = render(Tooltip, {
+      props: { text: 'Tip' },
+      slots: { default: '<span>Trigger</span>' },
+    });
+    expect(container.querySelector('.tooltip-top')).toBeTruthy();
+  });
+
+  it('applies all position variants', () => {
+    const positions = ['top', 'bottom', 'left', 'right'] as const;
+    positions.forEach((position) => {
+      const { container, unmount } = render(Tooltip, {
+        props: { text: 'Tip', position },
+        slots: { default: '<span>Trigger</span>' },
+      });
+      expect(container.querySelector(`.tooltip-${position}`)).toBeTruthy();
+      unmount();
+    });
+  });
+
+  it('applies color variant class', () => {
+    const { container } = render(Tooltip, {
+      props: { text: 'Tip', color: 'primary' },
+      slots: { default: '<span>Trigger</span>' },
+    });
+    expect(container.querySelector('.tooltip-primary')).toBeTruthy();
+  });
+
+  it('applies all color variants', () => {
+    const colors = ['primary', 'secondary', 'accent', 'success', 'warning', 'error', 'info', 'neutral'] as const;
+    colors.forEach((color) => {
+      const { container, unmount } = render(Tooltip, {
+        props: { text: 'Tip', color },
+        slots: { default: '<span>Trigger</span>' },
+      });
+      expect(container.querySelector(`.tooltip-${color}`)).toBeTruthy();
+      unmount();
+    });
+  });
+
+  it('applies tooltip-open class when forceOpen is true', () => {
+    const { container } = render(Tooltip, {
+      props: { text: 'Tip', forceOpen: true },
+      slots: { default: '<span>Trigger</span>' },
+    });
+    expect(container.querySelector('.tooltip-open')).toBeTruthy();
+  });
+
+  it('does not apply tooltip-open class by default', () => {
+    const { container } = render(Tooltip, {
+      props: { text: 'Tip' },
+      slots: { default: '<span>Trigger</span>' },
+    });
+    expect(container.querySelector('.tooltip-open')).toBeFalsy();
+  });
+
+  it('has aria-describedby linking to a role="tooltip" element', () => {
+    const { container } = render(Tooltip, {
+      props: { text: 'Accessible tip' },
+      slots: { default: '<span>Trigger</span>' },
+    });
+    const wrapper = container.querySelector('.tooltip');
+    const describedBy = wrapper?.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+
+    const tooltipEl = screen.getByRole('tooltip');
+    expect(tooltipEl).toBeTruthy();
+    expect(tooltipEl.id).toBe(describedBy);
+    expect(tooltipEl.textContent).toBe('Accessible tip');
+  });
+
+  it('hides the tooltip text visually with sr-only', () => {
+    render(Tooltip, {
+      props: { text: 'Hidden visually' },
+      slots: { default: '<span>Trigger</span>' },
+    });
+    const tooltipEl = screen.getByRole('tooltip');
+    expect(tooltipEl.classList.contains('sr-only')).toBe(true);
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(Tooltip, {
+      props: { text: 'Tip', className: 'custom-tooltip' },
+      slots: { default: '<span>Trigger</span>' },
+    });
+    expect(container.querySelector('.custom-tooltip')).toBeTruthy();
+  });
+});

--- a/packages/vue/src/__tests__/utility/Tooltip.test.ts
+++ b/packages/vue/src/__tests__/utility/Tooltip.test.ts
@@ -83,19 +83,25 @@ describe('Tooltip', () => {
     expect(container.querySelector('.tooltip-open')).toBeFalsy();
   });
 
-  it('has aria-describedby linking to a role="tooltip" element', () => {
+  it('exposes tooltipId via slot props and has role="tooltip" element', () => {
     const { container } = render(Tooltip, {
       props: { text: 'Accessible tip' },
-      slots: { default: '<span>Trigger</span>' },
+      slots: {
+        default: `<template #default="{ tooltipId }">
+          <span :aria-describedby="tooltipId">Trigger</span>
+        </template>`,
+      },
     });
-    const wrapper = container.querySelector('.tooltip');
-    const describedBy = wrapper?.getAttribute('aria-describedby');
-    expect(describedBy).toBeTruthy();
 
     const tooltipEl = screen.getByRole('tooltip');
     expect(tooltipEl).toBeTruthy();
-    expect(tooltipEl.id).toBe(describedBy);
     expect(tooltipEl.textContent).toBe('Accessible tip');
+    expect(tooltipEl.id).toBeTruthy();
+
+    // Verify the slot consumer can use the tooltipId
+    const trigger = container.querySelector('[aria-describedby]');
+    expect(trigger).toBeTruthy();
+    expect(trigger?.getAttribute('aria-describedby')).toBe(tooltipEl.id);
   });
 
   it('hides the tooltip text visually with sr-only', () => {

--- a/packages/vue/src/components/utility/Clipboard/Clipboard.vue
+++ b/packages/vue/src/components/utility/Clipboard/Clipboard.vue
@@ -46,6 +46,10 @@ const buttonClasses = computed(() =>
 );
 
 async function handleCopy() {
+  if (!navigator.clipboard?.writeText) {
+    emit('error', new Error('Clipboard API not available'));
+    return;
+  }
   try {
     await navigator.clipboard.writeText(props.text);
     copied.value = true;

--- a/packages/vue/src/components/utility/Clipboard/Clipboard.vue
+++ b/packages/vue/src/components/utility/Clipboard/Clipboard.vue
@@ -42,12 +42,7 @@ onUnmounted(() => {
 });
 
 const buttonClasses = computed(() =>
-  cn(
-    'btn',
-    props.color && colorMap[props.color],
-    sizeMap[props.size],
-    props.className,
-  ),
+  cn('btn', props.color && colorMap[props.color], sizeMap[props.size], props.className),
 );
 
 async function handleCopy() {
@@ -72,16 +67,10 @@ async function handleCopy() {
     :aria-label="copied ? successLabel : label"
     @click="handleCopy"
   >
-    <slot
-      v-if="!copied"
-      name="default"
-    >
+    <slot v-if="!copied" name="default">
       {{ label }}
     </slot>
-    <slot
-      v-else
-      name="success"
-    >
+    <slot v-else name="success">
       {{ successLabel }}
     </slot>
   </button>

--- a/packages/vue/src/components/utility/Clipboard/Clipboard.vue
+++ b/packages/vue/src/components/utility/Clipboard/Clipboard.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+/** @module Clipboard */
+import { computed, ref, onUnmounted } from 'vue';
+import { cn } from '@artisanpack-ui/tokens';
+import type { ClipboardProps } from './types';
+
+const colorMap: Record<string, string> = {
+  primary: 'btn-primary',
+  secondary: 'btn-secondary',
+  accent: 'btn-accent',
+  success: 'btn-success',
+  warning: 'btn-warning',
+  error: 'btn-error',
+  info: 'btn-info',
+  neutral: 'btn-neutral',
+};
+
+const sizeMap: Record<string, string> = {
+  xs: 'btn-xs',
+  sm: 'btn-sm',
+  md: '',
+  lg: 'btn-lg',
+};
+
+const props = withDefaults(defineProps<ClipboardProps>(), {
+  label: 'Copy',
+  successLabel: 'Copied!',
+  successDuration: 2000,
+  size: 'md',
+});
+
+const emit = defineEmits<{
+  copy: [];
+  error: [error: unknown];
+}>();
+
+const copied = ref(false);
+let copyTimeout: ReturnType<typeof setTimeout> | null = null;
+
+onUnmounted(() => {
+  if (copyTimeout) clearTimeout(copyTimeout);
+});
+
+const buttonClasses = computed(() =>
+  cn(
+    'btn',
+    props.color && colorMap[props.color],
+    sizeMap[props.size],
+    props.className,
+  ),
+);
+
+async function handleCopy() {
+  try {
+    await navigator.clipboard.writeText(props.text);
+    copied.value = true;
+    emit('copy');
+    if (copyTimeout) clearTimeout(copyTimeout);
+    copyTimeout = setTimeout(() => {
+      copied.value = false;
+    }, props.successDuration);
+  } catch (error) {
+    emit('error', error);
+  }
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    :class="buttonClasses"
+    :aria-label="copied ? successLabel : label"
+    @click="handleCopy"
+  >
+    <slot v-if="!copied" name="default">{{ label }}</slot>
+    <slot v-else name="success">{{ successLabel }}</slot>
+  </button>
+</template>

--- a/packages/vue/src/components/utility/Clipboard/Clipboard.vue
+++ b/packages/vue/src/components/utility/Clipboard/Clipboard.vue
@@ -72,7 +72,17 @@ async function handleCopy() {
     :aria-label="copied ? successLabel : label"
     @click="handleCopy"
   >
-    <slot v-if="!copied" name="default">{{ label }}</slot>
-    <slot v-else name="success">{{ successLabel }}</slot>
+    <slot
+      v-if="!copied"
+      name="default"
+    >
+      {{ label }}
+    </slot>
+    <slot
+      v-else
+      name="success"
+    >
+      {{ successLabel }}
+    </slot>
   </button>
 </template>

--- a/packages/vue/src/components/utility/Clipboard/types.ts
+++ b/packages/vue/src/components/utility/Clipboard/types.ts
@@ -1,0 +1,24 @@
+import type { DaisyColor, Size } from '@artisanpack-ui/tokens';
+
+/**
+ * Props for the Clipboard component.
+ *
+ * A button that copies the provided text to the clipboard and displays
+ * success feedback briefly after copying.
+ */
+export interface ClipboardProps {
+  /** The text to copy to the clipboard. */
+  text: string;
+  /** Label text for the button. @defaultValue `'Copy'` */
+  label?: string;
+  /** Label text shown after a successful copy. @defaultValue `'Copied!'` */
+  successLabel?: string;
+  /** Duration in milliseconds to show the success state. @defaultValue `2000` */
+  successDuration?: number;
+  /** The DaisyUI color variant applied to the button. */
+  color?: DaisyColor;
+  /** The size of the button. @defaultValue `'md'` */
+  size?: Size;
+  /** Additional CSS classes. */
+  className?: string;
+}

--- a/packages/vue/src/components/utility/Icon/Icon.vue
+++ b/packages/vue/src/components/utility/Icon/Icon.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+/** @module Icon */
+import { computed } from 'vue';
+import { cn } from '@artisanpack-ui/tokens';
+import type { DaisyColor, Size } from '@artisanpack-ui/tokens';
+import type { IconProps } from './types';
+
+const props = withDefaults(defineProps<IconProps>(), {
+  size: 'md',
+});
+
+const colorMap: Record<DaisyColor, string> = {
+  primary: 'text-primary',
+  secondary: 'text-secondary',
+  accent: 'text-accent',
+  success: 'text-success',
+  warning: 'text-warning',
+  error: 'text-error',
+  info: 'text-info',
+  neutral: 'text-neutral',
+};
+
+const sizeMap: Record<Size, string> = {
+  xs: 'w-3 h-3',
+  sm: 'w-4 h-4',
+  md: 'w-5 h-5',
+  lg: 'w-6 h-6',
+};
+
+const iconClasses = computed(() =>
+  cn('inline-flex shrink-0', sizeMap[props.size], props.color && colorMap[props.color], props.className),
+);
+</script>
+
+<template>
+  <span
+    :class="iconClasses"
+    :role="ariaLabel ? 'img' : 'presentation'"
+    :aria-label="ariaLabel"
+    :aria-hidden="ariaLabel ? undefined : 'true'"
+  >
+    <slot />
+  </span>
+</template>

--- a/packages/vue/src/components/utility/Icon/Icon.vue
+++ b/packages/vue/src/components/utility/Icon/Icon.vue
@@ -28,7 +28,12 @@ const sizeMap: Record<Size, string> = {
 };
 
 const iconClasses = computed(() =>
-  cn('inline-flex shrink-0', sizeMap[props.size], props.color && colorMap[props.color], props.className),
+  cn(
+    'inline-flex shrink-0',
+    sizeMap[props.size],
+    props.color && colorMap[props.color],
+    props.className,
+  ),
 );
 </script>
 

--- a/packages/vue/src/components/utility/Icon/types.ts
+++ b/packages/vue/src/components/utility/Icon/types.ts
@@ -1,0 +1,21 @@
+import type { DaisyColor, Size } from '@artisanpack-ui/tokens';
+
+/**
+ * Props for the Icon component.
+ *
+ * Renders an SVG icon with configurable size and color. Supports passing
+ * raw SVG content via the default slot or referencing a named icon from
+ * a registered icon set.
+ */
+export interface IconProps {
+  /** The name of the icon to render (e.g., 'home', 'user'). Used to look up the icon in registered sets. */
+  name?: string;
+  /** The size of the icon. Maps to DaisyUI size classes. @defaultValue `'md'` */
+  size?: Size;
+  /** The DaisyUI color variant applied to the icon. */
+  color?: DaisyColor;
+  /** Accessible label for the icon. When omitted, the icon is treated as decorative (aria-hidden). */
+  ariaLabel?: string;
+  /** Additional CSS classes. */
+  className?: string;
+}

--- a/packages/vue/src/components/utility/Icon/types.ts
+++ b/packages/vue/src/components/utility/Icon/types.ts
@@ -3,13 +3,10 @@ import type { DaisyColor, Size } from '@artisanpack-ui/tokens';
 /**
  * Props for the Icon component.
  *
- * Renders an SVG icon with configurable size and color. Supports passing
- * raw SVG content via the default slot or referencing a named icon from
- * a registered icon set.
+ * Renders an SVG icon with configurable size and color. Pass SVG content
+ * via the default slot.
  */
 export interface IconProps {
-  /** The name of the icon to render (e.g., 'home', 'user'). Used to look up the icon in registered sets. */
-  name?: string;
   /** The size of the icon. Maps to DaisyUI size classes. @defaultValue `'md'` */
   size?: Size;
   /** The DaisyUI color variant applied to the icon. */

--- a/packages/vue/src/components/utility/Markdown/Markdown.vue
+++ b/packages/vue/src/components/utility/Markdown/Markdown.vue
@@ -1,0 +1,165 @@
+<script setup lang="ts">
+/** @module Markdown */
+import { computed } from 'vue';
+import { cn } from '@artisanpack-ui/tokens';
+import type { MarkdownProps } from './types';
+
+const props = defineProps<MarkdownProps>();
+
+/**
+ * Minimal markdown-to-HTML converter.
+ * Handles headings, bold, italic, links, images, lists, code blocks,
+ * inline code, blockquotes, horizontal rules, and paragraphs.
+ */
+function parseMarkdown(md: string): string {
+  let html = md;
+
+  // Fenced code blocks (``` ... ```)
+  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_match, _lang, code) => {
+    return `<pre><code>${escapeHtml(code.trimEnd())}</code></pre>`;
+  });
+
+  // Split into lines for block-level processing
+  const lines = html.split('\n');
+  const result: string[] = [];
+  let inList: 'ul' | 'ol' | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+
+    // Skip lines inside pre blocks (already handled)
+    if (line.includes('<pre>') || line.includes('</pre>')) {
+      result.push(line);
+      continue;
+    }
+
+    // Horizontal rules
+    if (/^(-{3,}|\*{3,}|_{3,})$/.test(line.trim())) {
+      if (inList) {
+        result.push(inList === 'ul' ? '</ul>' : '</ol>');
+        inList = null;
+      }
+      result.push('<hr>');
+      continue;
+    }
+
+    // Headings
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      if (inList) {
+        result.push(inList === 'ul' ? '</ul>' : '</ol>');
+        inList = null;
+      }
+      const level = headingMatch[1].length;
+      result.push(`<h${level}>${applyInline(headingMatch[2])}</h${level}>`);
+      continue;
+    }
+
+    // Blockquotes
+    const blockquoteMatch = line.match(/^>\s?(.*)$/);
+    if (blockquoteMatch) {
+      if (inList) {
+        result.push(inList === 'ul' ? '</ul>' : '</ol>');
+        inList = null;
+      }
+      result.push(`<blockquote><p>${applyInline(blockquoteMatch[1])}</p></blockquote>`);
+      continue;
+    }
+
+    // Unordered list items
+    const ulMatch = line.match(/^[-*+]\s+(.+)$/);
+    if (ulMatch) {
+      if (inList !== 'ul') {
+        if (inList) result.push('</ol>');
+        result.push('<ul>');
+        inList = 'ul';
+      }
+      result.push(`<li>${applyInline(ulMatch[1])}</li>`);
+      continue;
+    }
+
+    // Ordered list items
+    const olMatch = line.match(/^\d+\.\s+(.+)$/);
+    if (olMatch) {
+      if (inList !== 'ol') {
+        if (inList) result.push('</ul>');
+        result.push('<ol>');
+        inList = 'ol';
+      }
+      result.push(`<li>${applyInline(olMatch[1])}</li>`);
+      continue;
+    }
+
+    // Close any open list if the line is not a list item
+    if (inList) {
+      result.push(inList === 'ul' ? '</ul>' : '</ol>');
+      inList = null;
+    }
+
+    // Empty line
+    if (line.trim() === '') {
+      continue;
+    }
+
+    // Paragraph
+    result.push(`<p>${applyInline(line)}</p>`);
+  }
+
+  if (inList) {
+    result.push(inList === 'ul' ? '</ul>' : '</ol>');
+  }
+
+  return result.join('\n');
+}
+
+/** Sanitize a URL to prevent javascript: and data: schemes. */
+function sanitizeUrl(url: string): string {
+  const trimmed = url.trim();
+  if (/^(javascript|data|vbscript):/i.test(trimmed)) {
+    return '#';
+  }
+  return trimmed;
+}
+
+/** Apply inline markdown transformations (bold, italic, links, images, code). */
+function applyInline(text: string): string {
+  // First escape HTML to prevent XSS
+  let result = escapeHtml(text);
+  // Inline code
+  result = result.replace(/`([^`]+)`/g, '<code>$1</code>');
+  // Images (before links to avoid conflict)
+  result = result.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_m, alt: string, src: string) =>
+    `<img src="${sanitizeUrl(src)}" alt="${alt}">`,
+  );
+  // Links
+  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, label: string, href: string) =>
+    `<a href="${sanitizeUrl(href)}">${label}</a>`,
+  );
+  // Bold
+  result = result.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  result = result.replace(/__(.+?)__/g, '<strong>$1</strong>');
+  // Italic
+  result = result.replace(/\*(.+?)\*/g, '<em>$1</em>');
+  result = result.replace(/_(.+?)_/g, '<em>$1</em>');
+  return result;
+}
+
+/** Escape HTML special characters. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const renderedHtml = computed(() => parseMarkdown(props.content));
+
+const containerClasses = computed(() => cn('prose', props.className));
+</script>
+
+<template>
+  <!-- eslint-disable-next-line vue/no-v-html -->
+  <div :class="containerClasses" v-html="renderedHtml" />
+</template>

--- a/packages/vue/src/components/utility/Markdown/Markdown.vue
+++ b/packages/vue/src/components/utility/Markdown/Markdown.vue
@@ -13,10 +13,13 @@ const props = defineProps<MarkdownProps>();
  */
 function parseMarkdown(md: string): string {
   let html = md;
+  const codeBlocks: string[] = [];
 
-  // Fenced code blocks (``` ... ```)
+  // Fenced code blocks (``` ... ```) — replace with placeholders
   html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_match, _lang, code) => {
-    return `<pre><code>${escapeHtml(code.trimEnd())}</code></pre>`;
+    const index = codeBlocks.length;
+    codeBlocks.push(`<pre><code>${escapeHtml(code.trimEnd())}</code></pre>`);
+    return `__CODE_BLOCK_${index}__`;
   });
 
   // Split into lines for block-level processing
@@ -25,11 +28,16 @@ function parseMarkdown(md: string): string {
   let inList: 'ul' | 'ol' | null = null;
 
   for (let i = 0; i < lines.length; i++) {
-    let line = lines[i];
+    const line = lines[i];
 
-    // Skip lines inside pre blocks (already handled)
-    if (line.includes('<pre>') || line.includes('</pre>')) {
-      result.push(line);
+    // Restore code block placeholders
+    const codeBlockMatch = line.match(/^__CODE_BLOCK_(\d+)__$/);
+    if (codeBlockMatch) {
+      if (inList) {
+        result.push(inList === 'ul' ? '</ul>' : '</ol>');
+        inList = null;
+      }
+      result.push(codeBlocks[Number(codeBlockMatch[1])]);
       continue;
     }
 
@@ -125,8 +133,15 @@ function sanitizeUrl(url: string): string {
 function applyInline(text: string): string {
   // First escape HTML to prevent XSS
   let result = escapeHtml(text);
-  // Inline code
-  result = result.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+  // Extract inline code spans into placeholders so their content is not re-parsed
+  const codeSpans: string[] = [];
+  result = result.replace(/`([^`]+)`/g, (_m, content: string) => {
+    const index = codeSpans.length;
+    codeSpans.push(`<code>${content}</code>`);
+    return `\uE000CS${index}\uE001`;
+  });
+
   // Images (before links to avoid conflict)
   result = result.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_m, alt: string, src: string) =>
     `<img src="${sanitizeUrl(src)}" alt="${alt}">`,
@@ -141,6 +156,10 @@ function applyInline(text: string): string {
   // Italic
   result = result.replace(/\*(.+?)\*/g, '<em>$1</em>');
   result = result.replace(/_(.+?)_/g, '<em>$1</em>');
+
+  // Restore code span placeholders
+  result = result.replace(/\uE000CS(\d+)\uE001/g, (_m, index: string) => codeSpans[Number(index)]);
+
   return result;
 }
 
@@ -161,5 +180,8 @@ const containerClasses = computed(() => cn('prose', props.className));
 
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -->
-  <div :class="containerClasses" v-html="renderedHtml" />
+  <div
+    :class="containerClasses"
+    v-html="renderedHtml"
+  />
 </template>

--- a/packages/vue/src/components/utility/Markdown/Markdown.vue
+++ b/packages/vue/src/components/utility/Markdown/Markdown.vue
@@ -12,7 +12,8 @@ const props = defineProps<MarkdownProps>();
  * inline code, blockquotes, horizontal rules, and paragraphs.
  */
 function parseMarkdown(md: string): string {
-  let html = md;
+  // Normalize line endings (CRLF/CR → LF)
+  let html = md.replace(/\r\n?/g, '\n');
   const codeBlocks: string[] = [];
 
   // Fenced code blocks (``` ... ```) — replace with placeholders
@@ -143,12 +144,14 @@ function applyInline(text: string): string {
   });
 
   // Images (before links to avoid conflict)
-  result = result.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_m, alt: string, src: string) =>
-    `<img src="${sanitizeUrl(src)}" alt="${alt}">`,
+  result = result.replace(
+    /!\[([^\]]*)\]\(([^)]+)\)/g,
+    (_m, alt: string, src: string) => `<img src="${sanitizeUrl(src)}" alt="${alt}">`,
   );
   // Links
-  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, label: string, href: string) =>
-    `<a href="${sanitizeUrl(href)}">${label}</a>`,
+  result = result.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    (_m, label: string, href: string) => `<a href="${sanitizeUrl(href)}">${label}</a>`,
   );
   // Bold
   result = result.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
@@ -180,8 +183,5 @@ const containerClasses = computed(() => cn('prose', props.className));
 
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -->
-  <div
-    :class="containerClasses"
-    v-html="renderedHtml"
-  />
+  <div :class="containerClasses" v-html="renderedHtml" />
 </template>

--- a/packages/vue/src/components/utility/Markdown/Markdown.vue
+++ b/packages/vue/src/components/utility/Markdown/Markdown.vue
@@ -143,16 +143,21 @@ function applyInline(text: string): string {
     return `\uE000CS${index}\uE001`;
   });
 
+  // Images and links — tokenize to protect from emphasis regexes
+  const tags: string[] = [];
   // Images (before links to avoid conflict)
-  result = result.replace(
-    /!\[([^\]]*)\]\(([^)]+)\)/g,
-    (_m, alt: string, src: string) => `<img src="${sanitizeUrl(src)}" alt="${alt}">`,
-  );
+  result = result.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_m, alt: string, src: string) => {
+    const index = tags.length;
+    tags.push(`<img src="${sanitizeUrl(src)}" alt="${alt}">`);
+    return `\uE000TG${index}\uE001`;
+  });
   // Links
-  result = result.replace(
-    /\[([^\]]+)\]\(([^)]+)\)/g,
-    (_m, label: string, href: string) => `<a href="${sanitizeUrl(href)}">${label}</a>`,
-  );
+  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, label: string, href: string) => {
+    const index = tags.length;
+    tags.push(`<a href="${sanitizeUrl(href)}">${label}</a>`);
+    return `\uE000TG${index}\uE001`;
+  });
+
   // Bold
   result = result.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
   result = result.replace(/__(.+?)__/g, '<strong>$1</strong>');
@@ -160,7 +165,8 @@ function applyInline(text: string): string {
   result = result.replace(/\*(.+?)\*/g, '<em>$1</em>');
   result = result.replace(/_(.+?)_/g, '<em>$1</em>');
 
-  // Restore code span placeholders
+  // Restore tag and code span placeholders
+  result = result.replace(/\uE000TG(\d+)\uE001/g, (_m, index: string) => tags[Number(index)]);
   result = result.replace(/\uE000CS(\d+)\uE001/g, (_m, index: string) => codeSpans[Number(index)]);
 
   return result;

--- a/packages/vue/src/components/utility/Markdown/types.ts
+++ b/packages/vue/src/components/utility/Markdown/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Props for the Markdown component.
+ *
+ * Renders markdown content as HTML using DaisyUI's prose typography classes.
+ * Supports basic markdown syntax including headings, bold, italic, links,
+ * lists, code blocks, blockquotes, horizontal rules, and images.
+ */
+export interface MarkdownProps {
+  /** The raw markdown string to render. */
+  content: string;
+  /** Additional CSS classes applied to the prose container. */
+  className?: string;
+}

--- a/packages/vue/src/components/utility/ThemeToggle/ThemeToggle.vue
+++ b/packages/vue/src/components/utility/ThemeToggle/ThemeToggle.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+/** @module ThemeToggle */
+import { computed, watch, onMounted } from 'vue';
+import { cn } from '@artisanpack-ui/tokens';
+import type { Size } from '@artisanpack-ui/tokens';
+import { useTheme } from '../../../composables/use-theme';
+import type { ColorScheme } from '../../../types/theme';
+import type { ThemeToggleProps } from './types';
+
+const props = withDefaults(defineProps<ThemeToggleProps>(), {
+  size: 'md',
+  persist: true,
+  storageKey: 'artisanpack-color-scheme',
+});
+
+const { colorScheme, resolvedColorScheme, setColorScheme } = useTheme();
+
+const sizeMap: Record<Size, string> = {
+  xs: 'btn-xs',
+  sm: 'btn-sm',
+  md: '',
+  lg: 'btn-lg',
+};
+
+const toggleClasses = computed(() =>
+  cn('btn btn-ghost', sizeMap[props.size], props.className),
+);
+
+const modes: ColorScheme[] = ['light', 'dark', 'system'];
+
+function cycle() {
+  const currentIndex = modes.indexOf(colorScheme.value);
+  const next = modes[(currentIndex + 1) % modes.length];
+  setColorScheme(next);
+}
+
+onMounted(() => {
+  if (props.persist && typeof window !== 'undefined') {
+    const stored = localStorage.getItem(props.storageKey) as ColorScheme | null;
+    if (stored && modes.includes(stored)) {
+      setColorScheme(stored);
+    }
+  }
+});
+
+watch(colorScheme, (value) => {
+  if (props.persist && typeof window !== 'undefined') {
+    localStorage.setItem(props.storageKey, value);
+  }
+});
+
+watch(resolvedColorScheme, (value) => {
+  if (typeof document !== 'undefined') {
+    document.documentElement.setAttribute('data-theme', value);
+  }
+});
+
+const ariaLabel = computed(() => {
+  const labels: Record<ColorScheme, string> = {
+    light: 'Switch to dark mode',
+    dark: 'Switch to system mode',
+    system: 'Switch to light mode',
+  };
+  return labels[colorScheme.value];
+});
+</script>
+
+<template>
+  <button
+    type="button"
+    :class="toggleClasses"
+    :aria-label="ariaLabel"
+    @click="cycle"
+  >
+    <!-- Sun icon for light mode -->
+    <svg
+      v-if="colorScheme === 'light'"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      class="w-5 h-5"
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
+    </svg>
+    <!-- Moon icon for dark mode -->
+    <svg
+      v-else-if="colorScheme === 'dark'"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      class="w-5 h-5"
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" />
+    </svg>
+    <!-- Computer icon for system mode -->
+    <svg
+      v-else
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      class="w-5 h-5"
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12V15a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 15V5.25A2.25 2.25 0 015.25 3h13.5A2.25 2.25 0 0121 5.25z" />
+    </svg>
+  </button>
+</template>

--- a/packages/vue/src/components/utility/ThemeToggle/ThemeToggle.vue
+++ b/packages/vue/src/components/utility/ThemeToggle/ThemeToggle.vue
@@ -36,24 +36,36 @@ function cycle() {
 
 onMounted(() => {
   if (props.persist && typeof window !== 'undefined') {
-    const stored = localStorage.getItem(props.storageKey) as ColorScheme | null;
-    if (stored && modes.includes(stored)) {
-      setColorScheme(stored);
+    try {
+      const stored = localStorage.getItem(props.storageKey) as ColorScheme | null;
+      if (stored && modes.includes(stored)) {
+        setColorScheme(stored);
+      }
+    } catch {
+      // localStorage may be unavailable (private browsing, storage quota, etc.)
     }
   }
 });
 
 watch(colorScheme, (value) => {
   if (props.persist && typeof window !== 'undefined') {
-    localStorage.setItem(props.storageKey, value);
+    try {
+      localStorage.setItem(props.storageKey, value);
+    } catch {
+      // localStorage may be unavailable
+    }
   }
 });
 
-watch(resolvedColorScheme, (value) => {
-  if (typeof document !== 'undefined') {
-    document.documentElement.setAttribute('data-theme', value);
-  }
-});
+watch(
+  resolvedColorScheme,
+  (value) => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('data-theme', value);
+    }
+  },
+  { immediate: true },
+);
 
 const ariaLabel = computed(() => {
   const labels: Record<ColorScheme, string> = {
@@ -82,7 +94,11 @@ const ariaLabel = computed(() => {
       stroke="currentColor"
       class="w-5 h-5"
     >
-      <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"
+      />
     </svg>
     <!-- Moon icon for dark mode -->
     <svg
@@ -94,7 +110,11 @@ const ariaLabel = computed(() => {
       stroke="currentColor"
       class="w-5 h-5"
     >
-      <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" />
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"
+      />
     </svg>
     <!-- Computer icon for system mode -->
     <svg
@@ -106,7 +126,11 @@ const ariaLabel = computed(() => {
       stroke="currentColor"
       class="w-5 h-5"
     >
-      <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12V15a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 15V5.25A2.25 2.25 0 015.25 3h13.5A2.25 2.25 0 0121 5.25z" />
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12V15a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 15V5.25A2.25 2.25 0 015.25 3h13.5A2.25 2.25 0 0121 5.25z"
+      />
     </svg>
   </button>
 </template>

--- a/packages/vue/src/components/utility/ThemeToggle/ThemeToggle.vue
+++ b/packages/vue/src/components/utility/ThemeToggle/ThemeToggle.vue
@@ -22,9 +22,7 @@ const sizeMap: Record<Size, string> = {
   lg: 'btn-lg',
 };
 
-const toggleClasses = computed(() =>
-  cn('btn btn-ghost', sizeMap[props.size], props.className),
-);
+const toggleClasses = computed(() => cn('btn btn-ghost', sizeMap[props.size], props.className));
 
 const modes: ColorScheme[] = ['light', 'dark', 'system'];
 
@@ -78,12 +76,7 @@ const ariaLabel = computed(() => {
 </script>
 
 <template>
-  <button
-    type="button"
-    :class="toggleClasses"
-    :aria-label="ariaLabel"
-    @click="cycle"
-  >
+  <button type="button" :class="toggleClasses" :aria-label="ariaLabel" @click="cycle">
     <!-- Sun icon for light mode -->
     <svg
       v-if="colorScheme === 'light'"
@@ -93,6 +86,8 @@ const ariaLabel = computed(() => {
       stroke-width="1.5"
       stroke="currentColor"
       class="w-5 h-5"
+      aria-hidden="true"
+      focusable="false"
     >
       <path
         stroke-linecap="round"
@@ -109,6 +104,8 @@ const ariaLabel = computed(() => {
       stroke-width="1.5"
       stroke="currentColor"
       class="w-5 h-5"
+      aria-hidden="true"
+      focusable="false"
     >
       <path
         stroke-linecap="round"
@@ -125,6 +122,8 @@ const ariaLabel = computed(() => {
       stroke-width="1.5"
       stroke="currentColor"
       class="w-5 h-5"
+      aria-hidden="true"
+      focusable="false"
     >
       <path
         stroke-linecap="round"

--- a/packages/vue/src/components/utility/ThemeToggle/types.ts
+++ b/packages/vue/src/components/utility/ThemeToggle/types.ts
@@ -1,0 +1,18 @@
+import type { Size } from '@artisanpack-ui/tokens';
+
+/**
+ * Props for the ThemeToggle component.
+ *
+ * A toggle control that switches between light, dark, and system color schemes.
+ * Integrates with the useTheme composable and persists the preference to localStorage.
+ */
+export interface ThemeToggleProps {
+  /** The size of the toggle. @defaultValue `'md'` */
+  size?: Size;
+  /** Whether to persist the color scheme preference to localStorage. @defaultValue `true` */
+  persist?: boolean;
+  /** The localStorage key used for persistence. @defaultValue `'artisanpack-color-scheme'` */
+  storageKey?: string;
+  /** Additional CSS classes. */
+  className?: string;
+}

--- a/packages/vue/src/components/utility/Tooltip/Tooltip.vue
+++ b/packages/vue/src/components/utility/Tooltip/Tooltip.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+/** @module Tooltip */
+import { computed, useId } from 'vue';
+import { cn } from '@artisanpack-ui/tokens';
+import type { DaisyColor } from '@artisanpack-ui/tokens';
+import type { TooltipPosition, TooltipProps } from './types';
+
+const props = withDefaults(defineProps<TooltipProps>(), {
+  position: 'top',
+  forceOpen: false,
+});
+
+const tooltipId = useId();
+
+const positionMap: Record<TooltipPosition, string> = {
+  top: 'tooltip-top',
+  bottom: 'tooltip-bottom',
+  left: 'tooltip-left',
+  right: 'tooltip-right',
+};
+
+const colorMap: Record<DaisyColor, string> = {
+  primary: 'tooltip-primary',
+  secondary: 'tooltip-secondary',
+  accent: 'tooltip-accent',
+  success: 'tooltip-success',
+  warning: 'tooltip-warning',
+  error: 'tooltip-error',
+  info: 'tooltip-info',
+  neutral: 'tooltip-neutral',
+};
+
+const tooltipClasses = computed(() =>
+  cn(
+    'tooltip',
+    positionMap[props.position],
+    props.color && colorMap[props.color],
+    props.forceOpen && 'tooltip-open',
+    props.className,
+  ),
+);
+</script>
+
+<template>
+  <div
+    :class="tooltipClasses"
+    :data-tip="text"
+    :aria-describedby="tooltipId"
+  >
+    <slot />
+    <span :id="tooltipId" role="tooltip" class="sr-only">{{ text }}</span>
+  </div>
+</template>

--- a/packages/vue/src/components/utility/Tooltip/Tooltip.vue
+++ b/packages/vue/src/components/utility/Tooltip/Tooltip.vue
@@ -42,15 +42,8 @@ const tooltipClasses = computed(() =>
 </script>
 
 <template>
-  <div
-    :class="tooltipClasses"
-    :data-tip="text"
-  >
+  <div :class="tooltipClasses" :data-tip="text">
     <slot :tooltip-id="tooltipId" />
-    <span
-      :id="tooltipId"
-      role="tooltip"
-      class="sr-only"
-    >{{ text }}</span>
+    <span :id="tooltipId" role="tooltip" class="sr-only">{{ text }}</span>
   </div>
 </template>

--- a/packages/vue/src/components/utility/Tooltip/Tooltip.vue
+++ b/packages/vue/src/components/utility/Tooltip/Tooltip.vue
@@ -45,9 +45,12 @@ const tooltipClasses = computed(() =>
   <div
     :class="tooltipClasses"
     :data-tip="text"
-    :aria-describedby="tooltipId"
   >
-    <slot />
-    <span :id="tooltipId" role="tooltip" class="sr-only">{{ text }}</span>
+    <slot :tooltip-id="tooltipId" />
+    <span
+      :id="tooltipId"
+      role="tooltip"
+      class="sr-only"
+    >{{ text }}</span>
   </div>
 </template>

--- a/packages/vue/src/components/utility/Tooltip/types.ts
+++ b/packages/vue/src/components/utility/Tooltip/types.ts
@@ -1,0 +1,26 @@
+import type { DaisyColor } from '@artisanpack-ui/tokens';
+
+/**
+ * Position of the tooltip relative to the trigger element.
+ */
+export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
+
+/**
+ * Props for the Tooltip component.
+ *
+ * Wraps a trigger element with a positioned tooltip that appears on hover
+ * and focus. Uses DaisyUI's tooltip classes with proper ARIA describedby
+ * for accessibility.
+ */
+export interface TooltipProps {
+  /** The tooltip text content. */
+  text: string;
+  /** Position of the tooltip relative to the trigger. @defaultValue `'top'` */
+  position?: TooltipPosition;
+  /** The DaisyUI color variant applied to the tooltip. */
+  color?: DaisyColor;
+  /** When true, forces the tooltip to remain open. @defaultValue `false` */
+  forceOpen?: boolean;
+  /** Additional CSS classes. */
+  className?: string;
+}

--- a/packages/vue/src/components/utility/index.ts
+++ b/packages/vue/src/components/utility/index.ts
@@ -1,2 +1,28 @@
-// utility components
-export {};
+/**
+ * @module utility
+ *
+ * Utility components for common UI needs including icons, theme toggling,
+ * tooltips, clipboard operations, and markdown rendering.
+ *
+ * @example
+ * ```vue
+ * import { Icon, ThemeToggle, Tooltip, Clipboard, Markdown } from '@artisanpack-ui/vue';
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+export { default as Icon } from './Icon/Icon.vue';
+export type { IconProps } from './Icon/types';
+
+export { default as ThemeToggle } from './ThemeToggle/ThemeToggle.vue';
+export type { ThemeToggleProps } from './ThemeToggle/types';
+
+export { default as Tooltip } from './Tooltip/Tooltip.vue';
+export type { TooltipProps, TooltipPosition } from './Tooltip/types';
+
+export { default as Clipboard } from './Clipboard/Clipboard.vue';
+export type { ClipboardProps } from './Clipboard/types';
+
+export { default as Markdown } from './Markdown/Markdown.vue';
+export type { MarkdownProps } from './Markdown/types';


### PR DESCRIPTION
## Description

Port 5 utility components to Vue 3 with TypeScript, Composition API, and DaisyUI/Tailwind CSS: Icon, ThemeToggle, Tooltip, Clipboard, and Markdown.

**Closes:** #8

## Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #8

## Motivation and Context

The Vue library needed utility components that provide common UI functionality like icons, tooltips, theme toggling, clipboard support, and markdown rendering.

## Changes Made

- **Icon**: SVG icon wrapper with size (xs/sm/md/lg) and DaisyUI color props, proper aria-hidden/role=img accessibility
- **ThemeToggle**: Cycles light → dark → system with SVG icons, integrates with `useTheme` composable, persists preference to localStorage
- **Tooltip**: DaisyUI tooltip with position (top/bottom/left/right), color variants, forceOpen, ARIA describedby accessibility
- **Clipboard**: Copy-to-clipboard button with configurable success feedback duration, custom default/success slots, copy/error events
- **Markdown**: Built-in markdown-to-HTML renderer with XSS protection (HTML escaping, javascript:/data: URL sanitization), supporting headings, bold/italic, links, images, lists, code blocks, blockquotes, horizontal rules
- Updated `utility/index.ts` with all component and type exports

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Node: v22
- Vitest + @testing-library/vue

**Tests Performed:**
1. 65 unit tests across 5 test files covering all utility components
2. Full test suite (644 tests) passes with no regressions
3. Manual testing in the dev app at `/packages/vue/utility-components`

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [x] Color contrast verified
- [x] ARIA labels checked

**Details:**
- Icon: aria-hidden="true" for decorative icons, role="img" + aria-label for semantic icons
- ThemeToggle: Descriptive aria-label that changes with current mode
- Tooltip: ARIA describedby linking trigger to role="tooltip" element, sr-only hidden text
- Clipboard: Dynamic aria-label reflecting copy/copied state

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:**
- Icon: 9 tests (slot content, sizes, colors, accessibility, className)
- ThemeToggle: 9 tests (render, cycling, persistence, localStorage restore, sizes)
- Tooltip: 12 tests (positions, colors, forceOpen, ARIA describedby, sr-only)
- Clipboard: 15 tests (labels, copy, success reset timer, events, colors, sizes, slots)
- Markdown: 20 tests (all block types, inline formatting, XSS prevention, URL sanitization)

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:**
JSDoc module comments and prop documentation in all type files.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds Clipboard, Icon, Markdown, ThemeToggle, and Tooltip utility components with accessibility, sizing/color options, sanitization, slots, and configurable behavior.
* **Tests**
  * Adds comprehensive test suites covering rendering, interaction, accessibility, state transitions, persistence, and edge cases for all utilities.
* **Chores**
  * Consolidates utility exports into a single public barrel for simpler imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->