### PR TITLE
docs: Documentation for v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to the ArtisanPack UI Vue monorepo will be documented in this file.
+
+Per-package changelogs are generated automatically by [Changesets](https://github.com/changesets/changesets) and live alongside each package. This root changelog provides a high-level overview across the monorepo.
+
+## [Unreleased]
+
+### Added
+
+- `@artisanpack-ui/vue` - 58 Vue 3 UI components across 7 categories (form, layout, navigation, data display, feedback, utility)
+- `@artisanpack-ui/vue` - `createArtisanPackUI` plugin with theme provider and default color scheme option
+- `@artisanpack-ui/vue` - `useTheme` and `useBreakpoint` composables
+- `@artisanpack-ui/vue` - Tree-shakeable sub-path exports per category
+- `@artisanpack-ui/vue` - Histoire stories for all components
+- `@artisanpack-ui/vue-laravel` - Inertia.js adapter wrappers for form, navigation, layout, and feedback components
+- `@artisanpack-ui/vue-laravel` - `useInertiaForm`, `useFlashMessages`, and `useAuth` composables
+- `@artisanpack-ui/vue-laravel` - `createArtisanPackUILaravel` plugin
+- Root documentation: README, CONTRIBUTING, LICENSE, and `docs/` directory

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,181 @@
+# Contributing to ArtisanPack UI for Vue
+
+Thank you for your interest in contributing! This guide covers everything you need to get started.
+
+## Local Development Setup
+
+### Prerequisites
+
+- Node.js 18+
+- npm 9+
+
+### Clone and install
+
+```bash
+git clone https://github.com/ArtisanPack-UI/vue.git
+cd vue
+npm install
+```
+
+### Build all packages
+
+```bash
+npm run build
+```
+
+### Run tests
+
+```bash
+npm run test
+```
+
+### Launch Histoire (component playground)
+
+```bash
+npm run story:dev
+```
+
+## Repository Structure
+
+```
+vue/
+├── packages/
+│   ├── vue/             # Core component library
+│   │   ├── src/
+│   │   │   ├── components/   # All Vue components by category
+│   │   │   ├── composables/  # useTheme, useBreakpoint
+│   │   │   ├── plugin/       # Vue plugin (createArtisanPackUI)
+│   │   │   ├── types/        # Shared type definitions
+│   │   │   └── __tests__/    # Unit tests
+│   │   └── visual-tests/     # Playwright visual regression tests
+│   └── vue-laravel/     # Inertia.js adapter package
+│       └── src/
+│           ├── components/   # Inertia-wrapped components
+│           ├── composables/  # useInertiaForm, useFlashMessages, useAuth
+│           ├── plugin/       # Vue plugin (createArtisanPackUILaravel)
+│           ├── types/        # Laravel-specific types
+│           └── __tests__/    # Unit tests
+├── docs/                # Documentation
+└── .changeset/          # Changeset configuration
+```
+
+## Code Style
+
+This project uses ESLint and Prettier for code formatting.
+
+```bash
+# Lint
+npm run lint
+
+# Format
+npm run format
+
+# Check formatting without writing
+npm run format:check
+```
+
+### Conventions
+
+- Use TypeScript for all source files
+- Define component props in a separate `types.ts` file as an interface (e.g., `ButtonProps`)
+- Add JSDoc/TSDoc comments to all exported interfaces, types, and functions
+- Use `defineProps<Props>()` with the imported type interface
+- Follow Vue 3 Composition API patterns with `<script setup lang="ts">`
+
+## Adding a New Component
+
+1. Create the component directory under the appropriate category:
+
+   ```
+   packages/vue/src/components/{category}/{ComponentName}/
+   ├── ComponentName.vue
+   ├── ComponentName.story.vue
+   └── types.ts
+   ```
+
+2. Define the props interface in `types.ts` with JSDoc comments.
+
+3. Export the component and types from the category barrel file (`{category}/index.ts`).
+
+4. Add a Histoire story file for interactive documentation.
+
+5. Add unit tests in `packages/vue/src/__tests__/`.
+
+## Pull Request Process
+
+1. **Create a branch** from `release/1.0` (or the current release branch):
+
+   ```bash
+   git checkout -b feature/123-short-description
+   ```
+
+2. **Make your changes** following the code style and conventions above.
+
+3. **Add a changeset** to document your change:
+
+   ```bash
+   npx changeset
+   ```
+
+   Select the affected packages and describe the change. Choose the appropriate bump type:
+   - `patch` for bug fixes
+   - `minor` for new features or enhancements
+   - `major` for breaking changes
+
+4. **Run checks** before pushing:
+
+   ```bash
+   npm run build
+   npm run test
+   npm run lint
+   npm run format:check
+   npm run type-check
+   ```
+
+5. **Push and open a PR** against the base branch. Fill out the PR template completely.
+
+6. **Address review feedback** and ensure CI passes.
+
+## Changeset Workflow
+
+This monorepo uses [Changesets](https://github.com/changesets/changesets) for versioning and changelog generation.
+
+- Every PR that changes package behavior should include a changeset
+- Documentation-only changes do not require a changeset
+- Run `npx changeset` to interactively create one
+- Changesets are committed as markdown files in `.changeset/`
+- On release, changesets are consumed to bump versions and generate changelogs
+
+## Running Tests
+
+```bash
+# All tests across all packages
+npm run test
+
+# Tests for a specific package
+npm run test --workspace=packages/vue
+npm run test --workspace=packages/vue-laravel
+
+# Watch mode (single package)
+cd packages/vue && npm run test:watch
+
+# Visual regression tests (requires Histoire build)
+npm run test:visual
+
+# Update visual snapshots
+npm run test:visual:update
+```
+
+## Type Checking
+
+```bash
+npm run type-check
+```
+
+## Reporting Issues
+
+Use the [issue templates](https://github.com/ArtisanPack-UI/vue/issues/new/choose) to report bugs, request features, or propose enhancements.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Jacob Martella
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,109 @@
+# ArtisanPack UI for Vue
+
+[![CI](https://github.com/ArtisanPack-UI/vue/actions/workflows/ci.yml/badge.svg)](https://github.com/ArtisanPack-UI/vue/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+A comprehensive Vue 3 UI component library for the ArtisanPack UI ecosystem, styled with DaisyUI and Tailwind CSS.
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| [`@artisanpack-ui/vue`](packages/vue) | 58 Vue 3 UI components organized by category (form, layout, navigation, display, data, feedback, utility) |
+| [`@artisanpack-ui/vue-laravel`](packages/vue-laravel) | Inertia.js adapter wrappers for seamless Laravel integration |
+
+## Quick Start
+
+### Install the core package
+
+```bash
+npm install @artisanpack-ui/vue
+```
+
+### Register the plugin
+
+```ts
+import { createApp } from 'vue';
+import { createArtisanPackUI } from '@artisanpack-ui/vue';
+import App from './App.vue';
+
+const app = createApp(App);
+app.use(createArtisanPackUI());
+app.mount('#app');
+```
+
+### Use components
+
+```vue
+<script setup lang="ts">
+import { Button, Input, Card } from '@artisanpack-ui/vue';
+</script>
+
+<template>
+  <Card>
+    <template #header>Sign In</template>
+    <Input label="Email" type="email" v-model="email" />
+    <Button color="primary" @click="submit">Log In</Button>
+  </Card>
+</template>
+```
+
+### Tree-shakeable sub-path imports
+
+Import only the categories you need to keep bundle sizes small:
+
+```ts
+import { Button, Input } from '@artisanpack-ui/vue/form';
+import { Card, Modal } from '@artisanpack-ui/vue/layout';
+import { Table } from '@artisanpack-ui/vue/data';
+```
+
+## Laravel / Inertia.js Integration
+
+```bash
+npm install @artisanpack-ui/vue-laravel
+```
+
+```ts
+import { createArtisanPackUILaravel } from '@artisanpack-ui/vue-laravel';
+
+app.use(createArtisanPackUILaravel());
+```
+
+See the [Laravel integration guide](https://github.com/ArtisanPack-UI/vue/wiki/Laravel-Inertia-Integration) for full setup instructions.
+
+## Requirements
+
+- Vue 3.5+
+- Tailwind CSS 4+
+- DaisyUI 5+
+- Node.js 18+
+
+## Documentation
+
+Full documentation is available on the [GitHub Wiki](https://github.com/ArtisanPack-UI/vue/wiki). Source files live in the [`docs/`](docs/) directory.
+
+- [Getting Started](https://github.com/ArtisanPack-UI/vue/wiki/Getting-Started)
+- [Component API Reference](https://github.com/ArtisanPack-UI/vue/wiki/Component-API-Reference)
+- [Design Tokens](https://github.com/ArtisanPack-UI/vue/wiki/Design-Tokens)
+- [Theming Guide](https://github.com/ArtisanPack-UI/vue/wiki/Theming)
+- [Composables Reference](https://github.com/ArtisanPack-UI/vue/wiki/Composables)
+- [Laravel / Inertia Integration](https://github.com/ArtisanPack-UI/vue/wiki/Laravel-Inertia-Integration)
+- [Migration from Livewire](https://github.com/ArtisanPack-UI/vue/wiki/Migration-from-Livewire)
+
+## Development
+
+```bash
+git clone https://github.com/ArtisanPack-UI/vue.git
+cd vue
+npm install
+npm run build
+npm run test
+npm run story:dev   # Launch Histoire component playground
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.
+
+## License
+
+[MIT](LICENSE)

--- a/docs/Component-API-Reference.md
+++ b/docs/Component-API-Reference.md
@@ -33,7 +33,7 @@ Many components share these common prop patterns:
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `color` | [`DaisyColor`](Design-Tokens) `\| 'ghost' \| 'outline'` | DaisyUI semantic color |
+| `color` | `DaisyColor \| 'ghost' \| 'outline'` | DaisyUI semantic color (see [[Design Tokens]]) |
 | `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | Component size |
 | `className` | `string` | Additional CSS classes |
 | `label` | `string` | Field label (form components) |

--- a/docs/Component-API-Reference.md
+++ b/docs/Component-API-Reference.md
@@ -1,0 +1,52 @@
+# Component API Reference
+
+Complete API reference for all ArtisanPack UI Vue components, organized by category.
+
+## Categories
+
+- [[Form Components]] — Button, Input, Select, Checkbox, Toggle, DatePicker, ColorPicker, RichTextEditor, and more
+- [[Layout Components]] — Card, Modal, Tabs, Accordion, Drawer, Dropdown, Grid, Stack, Popover
+- [[Navigation Components]] — Menu, Breadcrumbs, Pagination, Steps, Navbar, Sidebar, SpotlightSearch
+- [[Data Display Components]] — Table, Chart, Calendar, Avatar, Badge, Progress, Stat, Timeline, Carousel, Code, Diff, Sparkline
+- [[Feedback Components]] — Alert, Toast, Loading, Skeleton, EmptyState, ErrorDisplay
+- [[Utility Components]] — Icon, ThemeToggle, Tooltip, Clipboard, Markdown
+
+## Import Patterns
+
+```ts
+// Import everything from the main entry
+import { Button, Card, Alert } from '@artisanpack-ui/vue';
+
+// Or import from category entry points for smaller bundles
+import { Button, Input } from '@artisanpack-ui/vue/form';
+import { Card, Modal } from '@artisanpack-ui/vue/layout';
+import { Menu } from '@artisanpack-ui/vue/navigation';
+import { Avatar, Badge } from '@artisanpack-ui/vue/display';
+import { Calendar, Chart, Table } from '@artisanpack-ui/vue/data';
+import { Alert, Toast } from '@artisanpack-ui/vue/feedback';
+import { Icon, Tooltip } from '@artisanpack-ui/vue/utility';
+```
+
+## Common Props
+
+Many components share these common prop patterns:
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `color` | [`DaisyColor`](Design-Tokens) `\| 'ghost' \| 'outline'` | DaisyUI semantic color |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | Component size |
+| `className` | `string` | Additional CSS classes |
+| `label` | `string` | Field label (form components) |
+| `error` | `string` | Validation error message (form components) |
+| `hint` | `string` | Helper text (form components) |
+
+## Slots
+
+Components use Vue named slots for flexible content areas. Common slot names:
+
+- `#default` — Main content
+- `#header` / `#footer` — Card, Modal
+- `#prefix` / `#suffix` — Input adornments
+- `#actions` — Modal action buttons
+- `#icon` — Custom icon content
+- `#trigger` — Popover, Dropdown trigger element

--- a/docs/Composables.md
+++ b/docs/Composables.md
@@ -1,0 +1,133 @@
+# Composables
+
+ArtisanPack UI for Vue provides two composables for theme management and responsive design.
+
+## useTheme
+
+Provides reactive access to the current color scheme preference and a setter to change it.
+
+### Usage
+
+```vue
+<script setup lang="ts">
+import { useTheme } from '@artisanpack-ui/vue';
+
+const { colorScheme, resolvedColorScheme, setColorScheme } = useTheme();
+</script>
+```
+
+### Prerequisites
+
+`useTheme()` must be called within a component tree where `provideTheme()` has been called (typically in `App.vue`). Calling it without a provider throws an error.
+
+### Return Value
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `colorScheme` | `Ref<ColorScheme>` | The current user-selected preference: `'light'`, `'dark'`, or `'system'` |
+| `resolvedColorScheme` | `ComputedRef<'light' \| 'dark'>` | The effective mode after evaluating a `'system'` preference. Always `'light'` or `'dark'`. |
+| `setColorScheme` | `(scheme: ColorScheme) => void` | Updates the color scheme preference |
+
+### Example
+
+```vue
+<template>
+  <header :data-theme="resolvedColorScheme">
+    <span>Mode: {{ resolvedColorScheme }}</span>
+    <button @click="setColorScheme('light')">Light</button>
+    <button @click="setColorScheme('dark')">Dark</button>
+    <button @click="setColorScheme('system')">System</button>
+  </header>
+</template>
+```
+
+---
+
+## provideTheme
+
+Sets up the theme context for the component tree. Call this in a root-level component.
+
+### Usage
+
+```vue
+<script setup lang="ts">
+import { provideTheme } from '@artisanpack-ui/vue';
+
+// Uses plugin default or 'system'
+const theme = provideTheme();
+
+// Explicit override
+const theme = provideTheme('dark');
+</script>
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `defaultColorScheme` | `ColorScheme` | Plugin default or `'system'` | Initial color scheme preference |
+
+### Return Value
+
+Returns the same `ThemeContextValue` as `useTheme()`.
+
+### Priority
+
+The default color scheme resolves in this order:
+1. Explicit argument to `provideTheme()`
+2. Plugin-level `defaultColorScheme` from `createArtisanPackUI()`
+3. `'system'`
+
+---
+
+## useBreakpoint
+
+Reactive viewport breakpoint detection using Tailwind CSS v4 default breakpoints.
+
+### Usage
+
+```vue
+<script setup lang="ts">
+import { useBreakpoint } from '@artisanpack-ui/vue';
+
+const { current, isMd, isLg } = useBreakpoint();
+</script>
+```
+
+### Return Value
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `current` | `Ref<Breakpoint>` | The currently active breakpoint name |
+| `isSm` | `Ref<boolean>` | `true` when viewport >= 640px |
+| `isMd` | `Ref<boolean>` | `true` when viewport >= 768px |
+| `isLg` | `Ref<boolean>` | `true` when viewport >= 1024px |
+| `isXl` | `Ref<boolean>` | `true` when viewport >= 1280px |
+| `is2xl` | `Ref<boolean>` | `true` when viewport >= 1536px |
+
+### Breakpoint Values
+
+| Name | Min Width |
+|------|-----------|
+| `xs` | 0px |
+| `sm` | 640px |
+| `md` | 768px |
+| `lg` | 1024px |
+| `xl` | 1280px |
+| `2xl` | 1536px |
+
+### Example
+
+```vue
+<template>
+  <div>
+    <p>Current: {{ current }}</p>
+    <SidebarNav v-if="isLg" />
+    <MobileNav v-else />
+  </div>
+</template>
+```
+
+### SSR Behavior
+
+On the server, `current` defaults to `'md'`. After hydration, it resolves to the actual viewport breakpoint.

--- a/docs/Composables.md
+++ b/docs/Composables.md
@@ -54,10 +54,16 @@ Sets up the theme context for the component tree. Call this in a root-level comp
 import { provideTheme } from '@artisanpack-ui/vue';
 
 // Uses plugin default or 'system'
-const theme = provideTheme();
+const themeDefault = provideTheme();
+</script>
+```
+
+```vue
+<script setup lang="ts">
+import { provideTheme } from '@artisanpack-ui/vue';
 
 // Explicit override
-const theme = provideTheme('dark');
+const themeDark = provideTheme('dark');
 </script>
 ```
 

--- a/docs/Composables.md
+++ b/docs/Composables.md
@@ -1,6 +1,6 @@
 # Composables
 
-ArtisanPack UI for Vue provides two composables for theme management and responsive design.
+ArtisanPack UI for Vue provides three composables for theme management and responsive design: `provideTheme`, `useTheme`, and `useBreakpoint`.
 
 ## useTheme
 

--- a/docs/Data-Display-Components.md
+++ b/docs/Data-Display-Components.md
@@ -64,7 +64,7 @@ npm install apexcharts vue3-apexcharts
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `type` | `ChartType` | `'bar'` | Chart type (`bar`, `line`, `area`, `donut`, `pie`, `radialBar`, `radar`, `polarArea`) |
+| `type` | `ChartType` | `'bar'` | Chart type: `'bar' \| 'line' \| 'area' \| 'donut' \| 'pie' \| 'radialBar' \| 'radar' \| 'polarArea'` |
 | `labels` | `string[]` | -- | X-axis / slice labels |
 | `series` | `ChartSeries[]` | -- | Multi-series data (bar, line, area) |
 | `data` | `ChartDataPoint[]` | -- | Simple data points (pie, donut) |

--- a/docs/Data-Display-Components.md
+++ b/docs/Data-Display-Components.md
@@ -1,0 +1,285 @@
+# Data Display Components
+
+```ts
+import { Avatar, Badge, Carousel, Code, Diff, Progress, Sparkline, Stat, Timeline } from '@artisanpack-ui/vue/display';
+import { Calendar, Chart, Table } from '@artisanpack-ui/vue/data';
+```
+
+---
+
+## Table
+
+Data table with headers, rows, sorting, and custom cell rendering via scoped slots.
+
+```vue
+<Table
+  :columns="[
+    { key: 'name', label: 'Name', sortable: true },
+    { key: 'email', label: 'Email' },
+    { key: 'role', label: 'Role', align: 'center' },
+  ]"
+  :rows="users"
+  striped
+  hoverable
+  :sort="currentSort"
+  @update:sort="currentSort = $event"
+>
+  <template #cell-name="{ row }">
+    <strong>{{ row.name }}</strong>
+  </template>
+</Table>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `columns` | `TableColumn[]` | **required** | Column definitions |
+| `rows` | `Record<string, unknown>[]` | **required** | Row data |
+| `striped` | `boolean` | `false` | Zebra striping |
+| `compact` | `boolean` | `false` | Compact mode |
+| `hoverable` | `boolean` | `false` | Hover highlighting |
+| `pinRows` | `boolean` | `false` | Pin header row |
+| `pinCols` | `boolean` | `false` | Pin first column |
+| `sort` | `SortState` | -- | Current sort state |
+| `loading` | `boolean` | `false` | Loading state |
+| `emptyMessage` | `string` | `'No data available'` | Empty state message |
+| `className` | `string` | -- | Additional CSS classes |
+
+Dynamic scoped slots named `#cell-{key}` for custom cell rendering. Each receives `{ row, column, value }`.
+
+---
+
+## Chart
+
+Chart component powered by ApexCharts with 8 chart types and DaisyUI color integration. Requires optional peer dependencies:
+
+```bash
+npm install apexcharts vue3-apexcharts
+```
+
+```vue
+<Chart type="bar" :labels="['Jan', 'Feb', 'Mar']" :series="[
+  { name: 'Sales', data: [30, 40, 35] },
+]" title="Monthly Sales" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `type` | `ChartType` | `'bar'` | Chart type (`bar`, `line`, `area`, `donut`, `pie`, `radialBar`, `radar`, `polarArea`) |
+| `labels` | `string[]` | -- | X-axis / slice labels |
+| `series` | `ChartSeries[]` | -- | Multi-series data (bar, line, area) |
+| `data` | `ChartDataPoint[]` | -- | Simple data points (pie, donut) |
+| `height` | `number \| string` | `350` | Chart height |
+| `width` | `number \| string` | -- | Chart width |
+| `color` | `DaisyColor` | -- | Default color |
+| `options` | `Record<string, unknown>` | -- | ApexCharts options (deep-merged) |
+| `showLegend` | `boolean` | `true` | Show legend |
+| `animated` | `boolean` | `true` | Enable animations |
+| `title` | `string` | -- | Chart title |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Calendar
+
+Date calendar with navigation and event markers.
+
+```vue
+<Calendar v-model="selectedDate" :events="events" :week-start="1" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `month` | `number` | current | Displayed month (1-12) |
+| `year` | `number` | current | Displayed year |
+| `modelValue` | `string` | -- | Selected date (`YYYY-MM-DD`, `v-model`) |
+| `events` | `CalendarEvent[]` | -- | Events to display |
+| `weekStart` | `0 \| 1` | `0` | First day of week (0 = Sunday, 1 = Monday) |
+| `minDate` | `string` | -- | Minimum selectable date (`YYYY-MM-DD`) |
+| `maxDate` | `string` | -- | Maximum selectable date (`YYYY-MM-DD`) |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Avatar
+
+User avatar with image, initials, or placeholder fallback.
+
+```vue
+<Avatar src="/photo.jpg" alt="Jane" size="lg" ring="primary" />
+<Avatar initials="JD" color="secondary" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `src` | `string` | -- | Image URL |
+| `alt` | `string` | -- | Alt text for image |
+| `initials` | `string` | -- | Initials when no image |
+| `size` | `Size` | `'md'` | Avatar size |
+| `shape` | `'circle' \| 'squircle' \| 'hexagon' \| 'triangle'` | `'circle'` | Avatar shape |
+| `online` | `boolean` | `false` | Online indicator |
+| `offline` | `boolean` | `false` | Offline indicator |
+| `ring` | `DaisyColor` | -- | Ring color |
+| `color` | `DaisyColor` | -- | Placeholder background color |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Badge
+
+Small status indicator with color variants and outline style.
+
+```vue
+<Badge value="New" color="primary" />
+<Badge :value="42" color="error" outline />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `string \| number` | -- | Badge text/number |
+| `color` | `DaisyColor` | -- | Color variant |
+| `size` | `Size` | `'md'` | Badge size |
+| `outline` | `boolean` | `false` | Outline style |
+| `ghost` | `boolean` | `false` | Ghost style |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Carousel
+
+Image/content slideshow with navigation controls.
+
+```vue
+<Carousel :slides="[
+  { id: 1, src: '/img1.jpg', alt: 'Slide 1', caption: 'First slide' },
+  { id: 2, src: '/img2.jpg', alt: 'Slide 2' },
+]" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `slides` | `CarouselSlide[]` | **required** | Slides to display |
+| `showArrows` | `boolean` | `true` | Show navigation arrows |
+| `showIndicators` | `boolean` | `true` | Show dot indicators |
+| `modelValue` | `number` | `0` | Current slide index (`v-model`) |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Code
+
+Code block with optional language label and copy functionality.
+
+```vue
+<Code code="const x = 42;" language="javascript" copyable line-numbers />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `code` | `string` | **required** | Code content |
+| `language` | `string` | -- | Language label |
+| `copyable` | `boolean` | `false` | Show copy button |
+| `inline` | `boolean` | `false` | Inline rendering |
+| `lineNumbers` | `boolean` | `false` | Show line numbers |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Diff
+
+Side-by-side or inline diff viewer for comparing two pieces of content.
+
+```vue
+<Diff before="Hello" after="Hello World" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `before` | `string` | **required** | Original content |
+| `after` | `string` | **required** | Modified content |
+| `beforeLabel` | `string` | `'Before'` | Label for original |
+| `afterLabel` | `string` | `'After'` | Label for modified |
+| `mode` | `'side-by-side' \| 'inline'` | `'side-by-side'` | Display mode |
+| `lineNumbers` | `boolean` | `true` | Show line numbers |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Progress
+
+Progress bar with percentage display and color variants.
+
+```vue
+<Progress :value="65" color="primary" show-value />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `number` | -- | Current value |
+| `max` | `number` | `100` | Maximum value |
+| `color` | `DaisyColor` | -- | Color variant |
+| `showValue` | `boolean` | `false` | Show percentage text |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Sparkline
+
+Compact inline chart rendered as SVG with line, area, or bar variants.
+
+```vue
+<Sparkline :data="[5, 10, 5, 20, 8, 15]" color="success" type="area" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `number[]` | **required** | Numeric data points |
+| `type` | `'line' \| 'area' \| 'bar'` | `'line'` | Chart type |
+| `height` | `number` | `40` | Height in pixels |
+| `width` | `number` | `data.length * 8` | Width in pixels |
+| `color` | `DaisyColor \| string` | `'primary'` | Chart color |
+| `strokeWidth` | `number` | `2` | Stroke width (line/area) |
+| `curve` | `boolean` | `true` | Smooth Catmull-Rom curves |
+| `fillOpacity` | `number` | `0.3` | Area fill opacity (0-1) |
+| `showTooltip` | `boolean` | `true` | Show tooltip on hover |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Stat
+
+Statistic display with label, value, description, and change indicator.
+
+```vue
+<Stat title="Revenue" value="$12,400" change="+12%" change-direction="up" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | **required** | Label text |
+| `value` | `string \| number` | **required** | Main statistic |
+| `description` | `string` | -- | Description below value |
+| `change` | `string` | -- | Change indicator text |
+| `changeDirection` | `'up' \| 'down' \| 'neutral'` | -- | Change direction for color coding |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Timeline
+
+Vertical or horizontal timeline for displaying events or activity.
+
+```vue
+<Timeline :items="[
+  { id: 1, title: 'Order placed', time: '2024-01-15', color: 'primary', start: true },
+  { id: 2, title: 'Shipped', time: '2024-01-17', color: 'success' },
+  { id: 3, title: 'Delivered', time: '2024-01-19', color: 'success', end: true },
+]" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `items` | `TimelineItem[]` | **required** | Timeline items |
+| `vertical` | `boolean` | `true` | Vertical layout |
+| `snap` | `boolean` | `false` | Alternate items left/right |
+| `compact` | `boolean` | `false` | Compact rendering |
+| `className` | `string` | -- | Additional CSS classes |

--- a/docs/Design-Tokens.md
+++ b/docs/Design-Tokens.md
@@ -1,0 +1,96 @@
+# Design Tokens
+
+ArtisanPack UI uses a shared `@artisanpack-ui/tokens` package to define framework-agnostic types that ensure consistency across the component library.
+
+## Shared Types
+
+### DaisyColor
+
+The set of DaisyUI semantic color names available to component `color` props:
+
+```ts
+type DaisyColor =
+  | 'primary'
+  | 'secondary'
+  | 'accent'
+  | 'neutral'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'error';
+```
+
+Used by: Button, Checkbox, Toggle, Radio, Range, Pin, Badge, Alert, Progress, and others.
+
+### Size
+
+Standard size scale for components:
+
+```ts
+type Size = 'xs' | 'sm' | 'md' | 'lg';
+```
+
+Used by: Button, Avatar, Badge, Loading, and others.
+
+### ColorScheme
+
+Theme mode preference:
+
+```ts
+type ColorScheme = 'light' | 'dark' | 'system';
+```
+
+Used by: `createArtisanPackUI()` plugin options and `provideTheme()` / `useTheme()` composables.
+
+### FormFieldProps
+
+Common props shared across form components:
+
+```ts
+interface FormFieldProps {
+  label?: string;
+  hint?: string;
+  error?: string;
+  id?: string;
+  required?: boolean;
+  disabled?: boolean;
+}
+```
+
+Most form components (Input, Select, Textarea, etc.) extend this base set of props.
+
+### GlassProps
+
+Props for glass morphism styling:
+
+```ts
+interface GlassProps {
+  glass?: boolean;
+}
+```
+
+Used by: Card.
+
+### ColorProps
+
+Props for color variants:
+
+```ts
+interface ColorProps {
+  color?: DaisyColor;
+}
+```
+
+## Importing Types
+
+Import types directly from `@artisanpack-ui/vue`:
+
+```ts
+import type { DaisyColor, Size, ColorScheme } from '@artisanpack-ui/vue';
+```
+
+Or from the tokens package if building a separate integration:
+
+```ts
+import type { DaisyColor, Size, FormFieldProps } from '@artisanpack-ui/tokens';
+```

--- a/docs/Feedback-Components.md
+++ b/docs/Feedback-Components.md
@@ -1,0 +1,157 @@
+# Feedback Components
+
+```ts
+import { Alert, EmptyState, ErrorDisplay, Loading, Skeleton, ToastProvider, ToastMessage, useToast } from '@artisanpack-ui/vue/feedback';
+```
+
+---
+
+## Alert
+
+Contextual feedback messages for success, warnings, information, and errors.
+
+```vue
+<Alert color="success" dismissible>Operation completed successfully.</Alert>
+<Alert color="error">Something went wrong.</Alert>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `color` | `'info' \| 'success' \| 'warning' \| 'error'` | -- | Color variant |
+| `dismissible` | `boolean` | `false` | Show close button |
+| `visible` | `boolean` | -- | Controlled visibility |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## EmptyState
+
+Placeholder shown when a list, table, or section has no content.
+
+```vue
+<EmptyState heading="No results" description="Try adjusting your search filters.">
+  <template #action><Button>Reset Filters</Button></template>
+</EmptyState>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `heading` | `string` | -- | Heading text |
+| `headingAs` | `'h1'-'h6'` | `'h3'` | Heading element |
+| `description` | `string` | -- | Description text |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## ErrorDisplay
+
+User-friendly error state with optional retry action.
+
+```vue
+<ErrorDisplay title="Failed to load data" message="Please check your connection." retryable @retry="fetchData" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | `'Something went wrong'` | Error title |
+| `message` | `string` | -- | Error message |
+| `retryable` | `boolean` | `false` | Show retry button |
+| `retryLabel` | `string` | `'Try again'` | Retry button text |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Loading
+
+Animated loading indicator with multiple animation styles.
+
+```vue
+<Loading color="primary" size="lg" variant="dots" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `color` | `DaisyColor` | -- | Color variant |
+| `size` | `Size` | -- | Indicator size |
+| `variant` | `'spinner' \| 'dots' \| 'ring' \| 'ball' \| 'bars' \| 'infinity'` | `'spinner'` | Animation style |
+| `ariaLabel` | `string` | `'Loading'` | Accessible label |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Skeleton
+
+Placeholder loading animation for content placeholders.
+
+```vue
+<Skeleton width="200px" height="1rem" />
+<Skeleton circle width="48px" height="48px" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `width` | `string` | -- | Width (CSS value) |
+| `height` | `string` | -- | Height (CSS value) |
+| `circle` | `boolean` | `false` | Circle shape |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Toast System
+
+A toast notification system with an imperative API.
+
+### Setup
+
+Wrap your app with `ToastProvider`:
+
+```vue
+<!-- App.vue -->
+<script setup>
+import { ToastProvider } from '@artisanpack-ui/vue/feedback';
+</script>
+
+<template>
+  <ToastProvider :default-duration="5000" :max="5">
+    <RouterView />
+  </ToastProvider>
+</template>
+```
+
+### Usage
+
+```vue
+<script setup>
+import { useToast } from '@artisanpack-ui/vue/feedback';
+
+const toast = useToast();
+
+function save() {
+  toast.success('Changes saved!');
+}
+
+function handleError() {
+  toast.error('Something went wrong.', 8000);
+}
+</script>
+```
+
+### ToastProvider Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `defaultDuration` | `number` | `5000` | Auto-dismiss duration (ms) |
+| `max` | `number` | `5` | Max simultaneous toasts |
+| `position` | `ToastPosition[]` | `['toast-end', 'toast-bottom']` | Position classes |
+
+### ToastAPI (from `useToast()`)
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `show` | `(options: ToastOptions) => string` | Show toast with full options |
+| `success` | `(message: string, duration?: number) => string` | Success toast |
+| `error` | `(message: string, duration?: number) => string` | Error toast |
+| `warning` | `(message: string, duration?: number) => string` | Warning toast |
+| `info` | `(message: string, duration?: number) => string` | Info toast |
+| `dismiss` | `(id: string) => void` | Dismiss a specific toast |
+| `dismissAll` | `() => void` | Dismiss all toasts |

--- a/docs/Feedback-Components.md
+++ b/docs/Feedback-Components.md
@@ -37,7 +37,7 @@ Placeholder shown when a list, table, or section has no content.
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `heading` | `string` | -- | Heading text |
-| `headingAs` | `'h1'-'h6'` | `'h3'` | Heading element |
+| `headingAs` | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'` | `'h3'` | Heading element |
 | `description` | `string` | -- | Description text |
 | `className` | `string` | -- | Additional CSS classes |
 

--- a/docs/Form-Components.md
+++ b/docs/Form-Components.md
@@ -1,0 +1,366 @@
+# Form Components
+
+```ts
+import { Button, Input, Select, Checkbox, Toggle, Radio, Textarea, Password, Pin, Range, DatePicker, ColorPicker, Editor, RichTextEditor, FileUpload } from '@artisanpack-ui/vue/form';
+```
+
+---
+
+## Button
+
+A versatile button that can render as a `<button>` or `<a>` element with badge, tooltip, loading, and responsive support.
+
+```vue
+<Button color="primary" @click="save">Save</Button>
+<Button link="/about" external>Learn More</Button>
+<Button :loading="submitting" color="success">Submit</Button>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Text label. Hidden on small screens when `responsive` is true |
+| `color` | `DaisyColor \| 'ghost' \| 'outline'` | -- | DaisyUI color variant |
+| `size` | `Size` | -- | Button size (`xs`, `sm`, `md`, `lg`) |
+| `loading` | `boolean` | `false` | Shows a loading spinner in place of the left icon |
+| `link` | `string` | -- | Renders as `<a>` element with this URL |
+| `external` | `boolean` | `false` | Opens link in new tab with `rel="noopener noreferrer"` |
+| `badge` | `string` | -- | Badge text after the label |
+| `badgeColor` | `DaisyColor \| 'ghost' \| 'outline'` | -- | Badge color variant |
+| `badgeClasses` | `string` | -- | Additional badge CSS classes |
+| `responsive` | `boolean` | `false` | Hides label on small screens |
+| `tooltip` | `string` | -- | Tooltip text on hover |
+| `tooltipPosition` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'top'` | Tooltip position |
+| `disabled` | `boolean` | `false` | Disabled state |
+| `type` | `'button' \| 'submit' \| 'reset'` | `'button'` | HTML type attribute |
+
+---
+
+## Input
+
+A text input with label, icons, prefix/suffix adornments, clearable action, and inline label mode.
+
+```vue
+<Input label="Email" type="email" v-model="email" />
+<Input label="Search" v-model="search" clearable inline />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Label text |
+| `hint` | `string` | -- | Helper text below the input |
+| `error` | `string` | -- | Error message (replaces hint, adds `aria-invalid`) |
+| `clearable` | `boolean` | `false` | Shows a clear (X) button |
+| `inline` | `boolean` | `false` | Floating/inline label mode |
+| `id` | `string` | auto | Custom element ID |
+| `required` | `boolean` | `false` | Required field |
+| `type` | `'text' \| 'email' \| 'number' \| 'password' \| 'search' \| 'tel' \| 'url' \| 'hidden'` | `'text'` | Input type |
+| `placeholder` | `string` | -- | Placeholder text |
+| `disabled` | `boolean` | `false` | Disabled state |
+| `readonly` | `boolean` | `false` | Read-only state |
+
+---
+
+## Select
+
+A dropdown select with option mapping, placeholder, icons, and inline label.
+
+```vue
+<Select label="Country" v-model="country" :options="countries" option-value="id" option-label="name" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Label text |
+| `hint` | `string` | -- | Helper text |
+| `error` | `string` | -- | Error message |
+| `placeholder` | `string` | -- | Disabled placeholder option text |
+| `placeholderValue` | `string` | `''` | Value for the placeholder option |
+| `inline` | `boolean` | `false` | Inline label mode |
+| `optionValue` | `string` | `'id'` | Property key for option values |
+| `optionLabel` | `string` | `'name'` | Property key for option labels |
+| `options` | `SelectOption[]` | -- | Array of option objects |
+| `id` | `string` | -- | Custom element ID |
+| `required` | `boolean` | `false` | Required field |
+| `disabled` | `boolean` | `false` | Disabled state |
+
+---
+
+## Checkbox
+
+Checkbox with label, card layout variant, and color support.
+
+```vue
+<Checkbox label="I agree to the terms" v-model="agreed" color="primary" />
+<Checkbox label="Premium" v-model="isPremium" card />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Label text |
+| `right` | `boolean` | `false` | Position label to the right |
+| `hint` | `string` | -- | Helper text |
+| `error` | `string` | -- | Error message |
+| `color` | `DaisyColor` | -- | Color variant |
+| `card` | `boolean` | `false` | Card layout mode |
+| `cardClass` | `string` | -- | Additional card CSS classes |
+| `id` | `string` | -- | Custom element ID |
+| `required` | `boolean` | `false` | Required field |
+| `disabled` | `boolean` | `false` | Disabled state |
+
+---
+
+## Toggle
+
+Switch/toggle rendered as a styled checkbox with `role="switch"`.
+
+```vue
+<Toggle label="Notifications" v-model="notificationsEnabled" color="success" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Label text |
+| `right` | `boolean` | `false` | Position label to the right |
+| `hint` | `string` | -- | Helper text |
+| `error` | `string` | -- | Error message |
+| `color` | `DaisyColor` | -- | Color variant |
+| `id` | `string` | -- | Custom element ID |
+| `required` | `boolean` | `false` | Required field |
+| `disabled` | `boolean` | `false` | Disabled state |
+
+---
+
+## Radio
+
+Radio button group from an options array with card layout and orientation support.
+
+```vue
+<Radio label="Plan" v-model="plan" :options="plans" option-value="id" option-label="name" />
+<Radio v-model="size" :options="sizes" card />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Group label (rendered as `<legend>`) |
+| `hint` | `string` | -- | Helper text |
+| `error` | `string` | -- | Error message |
+| `color` | `DaisyColor` | -- | Color variant |
+| `optionValue` | `string` | `'id'` | Property key for option values |
+| `optionLabel` | `string` | `'name'` | Property key for option labels |
+| `optionHint` | `string` | `'hint'` | Property key for option hint text |
+| `options` | `RadioOption[]` | -- | Array of option objects |
+| `inline` | `boolean` | `false` | Horizontal layout (when `card` is false) |
+| `card` | `boolean` | `false` | Card layout mode |
+| `cardClass` | `string` | -- | Additional card CSS classes |
+| `id` | `string` | -- | Custom fieldset ID |
+| `name` | `string` | -- | Radio group name |
+| `required` | `boolean` | `false` | Required field |
+
+---
+
+## Textarea
+
+Multi-line text input with label, inline mode, and read-only styling.
+
+```vue
+<Textarea label="Description" v-model="description" rows="5" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Label text |
+| `hint` | `string` | -- | Helper text |
+| `error` | `string` | -- | Error message |
+| `inline` | `boolean` | `false` | Inline label mode |
+| `id` | `string` | -- | Custom element ID |
+| `required` | `boolean` | `false` | Required field |
+| `readonly` | `boolean` | `false` | Read-only state |
+| `placeholder` | `string` | -- | Placeholder text |
+| `rows` | `number` | -- | Visible text rows |
+| `disabled` | `boolean` | `false` | Disabled state |
+
+---
+
+## Password
+
+Password input with built-in visibility toggle and clearable action.
+
+```vue
+<Password label="Password" v-model="password" />
+<Password label="Confirm" v-model="confirm" hide-toggle />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Label text |
+| `hint` | `string` | -- | Helper text |
+| `error` | `string` | -- | Error message |
+| `inline` | `boolean` | `false` | Inline label mode |
+| `clearable` | `boolean` | `false` | Shows a clear button |
+| `hideToggle` | `boolean` | `false` | Hides the visibility toggle |
+| `id` | `string` | -- | Custom element ID |
+| `required` | `boolean` | `false` | Required field |
+| `placeholder` | `string` | -- | Placeholder text |
+| `disabled` | `boolean` | `false` | Disabled state |
+
+---
+
+## Pin
+
+Row of single-character inputs for PIN/OTP entry with auto-focus and paste support.
+
+```vue
+<Pin :length="6" v-model="code" numeric />
+<Pin :length="4" v-model="pin" hide />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `length` | `number` | **required** | Number of input fields |
+| `numeric` | `boolean` | `false` | Digits only (0-9) |
+| `hide` | `boolean` | `false` | Mask input characters |
+| `error` | `string` | -- | Error message |
+| `color` | `DaisyColor` | -- | Color variant |
+| `id` | `string` | -- | ID prefix for inputs |
+| `disabled` | `boolean` | `false` | Disabled state |
+
+---
+
+## Range
+
+Styled range slider with DaisyUI color variants.
+
+```vue
+<Range label="Volume" v-model="volume" :min="0" :max="100" color="primary" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Label text |
+| `hint` | `string` | -- | Helper text |
+| `error` | `string` | -- | Error message |
+| `color` | `DaisyColor` | -- | Color variant |
+| `id` | `string` | -- | Custom element ID |
+| `min` | `number` | `0` | Minimum value |
+| `max` | `number` | `100` | Maximum value |
+| `step` | `number` | -- | Step increment |
+| `required` | `boolean` | `false` | Required field |
+| `disabled` | `boolean` | `false` | Disabled state |
+
+---
+
+## DatePicker
+
+Native HTML date input with label, inline mode, and date type selection.
+
+```vue
+<DatePicker label="Start Date" v-model="startDate" />
+<DatePicker label="Time" v-model="time" date-type="time" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Label text |
+| `hint` | `string` | -- | Helper text |
+| `error` | `string` | -- | Error message |
+| `inline` | `boolean` | `false` | Inline label mode |
+| `dateType` | `'date' \| 'datetime-local' \| 'time' \| 'month' \| 'week'` | `'date'` | Input type |
+| `id` | `string` | -- | Custom element ID |
+| `required` | `boolean` | `false` | Required field |
+| `min` | `string` | -- | Minimum date/time |
+| `max` | `string` | -- | Maximum date/time |
+| `disabled` | `boolean` | `false` | Disabled state |
+
+---
+
+## ColorPicker
+
+Native color input with hex display, optional clear and random buttons.
+
+```vue
+<ColorPicker label="Brand Color" v-model="brandColor" clearable random />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Label text |
+| `hint` | `string` | -- | Helper text |
+| `error` | `string` | -- | Error message |
+| `clearable` | `boolean` | `false` | Shows a clear button |
+| `random` | `boolean` | `false` | Shows a random color button |
+| `id` | `string` | -- | Custom element ID |
+| `required` | `boolean` | `false` | Required field |
+| `defaultValue` | `string` | `'#000000'` | Color when cleared |
+| `disabled` | `boolean` | `false` | Disabled state |
+
+---
+
+## Editor
+
+Monospace textarea for code or structured text editing.
+
+```vue
+<Editor label="JSON Config" v-model="config" :rows="15" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Label text |
+| `hint` | `string` | -- | Helper text |
+| `error` | `string` | -- | Error message |
+| `id` | `string` | -- | Custom element ID |
+| `required` | `boolean` | `false` | Required field |
+| `placeholder` | `string` | -- | Placeholder text |
+| `rows` | `number` | `12` | Visible text rows |
+| `disabled` | `boolean` | `false` | Disabled state |
+| `readonly` | `boolean` | `false` | Read-only state |
+
+---
+
+## RichTextEditor
+
+ContentEditable wrapper with toolbar support for rich text editing.
+
+> **Security:** Always sanitize `modelValue` (e.g., with DOMPurify) before passing user-generated content.
+
+```vue
+<RichTextEditor label="Content" v-model="body" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Label text |
+| `hint` | `string` | -- | Helper text |
+| `error` | `string` | -- | Error message |
+| `minHeight` | `string` | `'200px'` | Minimum height of the editable area |
+| `id` | `string` | -- | Custom element ID |
+| `required` | `boolean` | `false` | Required field |
+| `disabled` | `boolean` | `false` | Disabled state |
+
+---
+
+## FileUpload
+
+File input with standard and drag-and-drop rendering modes.
+
+```vue
+<FileUpload label="Avatar" accept="image/*" v-model="file" />
+<FileUpload label="Documents" with-drag-drop multiple :progress="uploadProgress" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- | Label text |
+| `hint` | `string` | -- | Helper text |
+| `error` | `string` | -- | Error message |
+| `withDragDrop` | `boolean` | `false` | Drag-and-drop zone mode |
+| `dragDropText` | `string` | `'Drop files here or click to browse'` | Custom drop zone text |
+| `dragDropClass` | `string` | -- | Additional drop zone CSS classes |
+| `progress` | `number` | -- | Upload progress (0-100) |
+| `hideProgress` | `boolean` | `false` | Hide progress bar |
+| `id` | `string` | -- | Custom element ID |
+| `required` | `boolean` | `false` | Required field |
+| `accept` | `string` | -- | Accepted file types |
+| `multiple` | `boolean` | `false` | Allow multiple files |
+| `disabled` | `boolean` | `false` | Disabled state |
+| `name` | `string` | -- | Name attribute for form submissions |

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,0 +1,129 @@
+# Getting Started
+
+This guide walks you through installing and configuring ArtisanPack UI for Vue.
+
+## Prerequisites
+
+- Node.js 18+
+- Vue 3.5+
+- Tailwind CSS 4+
+- DaisyUI 5+
+
+## Installation
+
+### 1. Install the package
+
+```bash
+npm install @artisanpack-ui/vue
+```
+
+### 2. Install peer dependencies
+
+Tailwind CSS and DaisyUI must be configured in your project:
+
+```bash
+npm install -D tailwindcss @tailwindcss/vite daisyui
+```
+
+Add Tailwind and DaisyUI to your CSS entry point:
+
+```css
+@import "tailwindcss";
+@plugin "daisyui";
+```
+
+### 3. Register the Vue plugin
+
+In your application entry file (e.g., `main.ts`):
+
+```ts
+import { createApp } from 'vue';
+import { createArtisanPackUI } from '@artisanpack-ui/vue';
+import App from './App.vue';
+
+const app = createApp(App);
+app.use(createArtisanPackUI());
+app.mount('#app');
+```
+
+### 4. Set up the theme provider
+
+Wrap your root component with `provideTheme()` to enable dark mode support:
+
+```vue
+<!-- App.vue -->
+<script setup lang="ts">
+import { provideTheme } from '@artisanpack-ui/vue';
+
+const { resolvedColorScheme } = provideTheme();
+</script>
+
+<template>
+  <div :data-theme="resolvedColorScheme">
+    <RouterView />
+  </div>
+</template>
+```
+
+## Using Components
+
+Import components directly for tree-shaking:
+
+```vue
+<script setup lang="ts">
+import { Button, Input, Card } from '@artisanpack-ui/vue';
+</script>
+
+<template>
+  <Card title="Sign In">
+    <Input label="Email" type="email" v-model="email" />
+    <Input label="Password" type="password" v-model="password" />
+    <Button color="primary" @click="submit">Log In</Button>
+  </Card>
+</template>
+```
+
+### Category imports
+
+Import from specific categories to reduce bundle size:
+
+```ts
+import { Button, Input, Select } from '@artisanpack-ui/vue/form';
+import { Card, Modal, Tabs } from '@artisanpack-ui/vue/layout';
+import { Menu, Breadcrumbs } from '@artisanpack-ui/vue/navigation';
+import { Avatar, Badge, Table } from '@artisanpack-ui/vue/display';
+import { Calendar, Chart } from '@artisanpack-ui/vue/data';
+import { Alert, Loading, ToastProvider } from '@artisanpack-ui/vue/feedback';
+import { Icon, ThemeToggle, Tooltip } from '@artisanpack-ui/vue/utility';
+```
+
+### Global registration (optional)
+
+If you prefer global components instead of imports:
+
+```ts
+import { createArtisanPackUI, Button, Card, Input } from '@artisanpack-ui/vue';
+
+app.use(createArtisanPackUI({
+  prefix: 'Ap',
+  components: { Button, Card, Input },
+}));
+
+// Now available as <ApButton />, <ApCard />, <ApInput />
+```
+
+## Plugin Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `prefix` | `string` | `'Ap'` | Prefix for globally registered component names |
+| `defaultColorScheme` | `'light' \| 'dark' \| 'system'` | `'system'` | Initial color scheme for the theme provider |
+| `components` | `Record<string, Component>` | `{}` | Components to register globally |
+
+## What's Next
+
+- [[Component API Reference]] — Full props, slots, and events for every component
+- [[Theming]] — Customize colors and dark mode
+- [[Design Tokens]] — Shared types and values
+- [[Composables]] — `useTheme` and `useBreakpoint`
+- [[Laravel Inertia Integration]] — Set up with Inertia.js

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,31 @@
+# ArtisanPack UI Vue
+
+A comprehensive Vue 3 UI component ecosystem for building modern web applications. Includes 58 components styled with [DaisyUI](https://daisyui.com/) and [Tailwind CSS](https://tailwindcss.com/), a shared design tokens package, and first-class [Laravel](https://laravel.com/) / [Inertia.js](https://inertiajs.com/) integration.
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| `@artisanpack-ui/vue` | 58 Vue 3 UI components (form, layout, navigation, data display, feedback, utility) |
+| `@artisanpack-ui/vue-laravel` | Inertia.js adapter wrappers for navigation, forms, auth, and toast integration |
+
+Both packages depend on `@artisanpack-ui/tokens` for shared design tokens (colors, sizes, types).
+
+## Guides
+
+- [[Getting Started]] — Installation, setup, and basic usage
+- [[Design Tokens]] — Colors, spacing, typography, and shared types
+- [[Theming]] — ThemeProvider, DaisyUI themes, dark mode, and custom themes
+- [[Composables]] — useTheme, provideTheme, and useBreakpoint
+- [[Laravel Inertia Integration]] — Forms, navigation, auth, and toast with Inertia.js
+- [[Migration from Livewire]] — Side-by-side migration guide from Livewire components
+
+## Component Reference
+
+- [[Component API Reference]] — Overview and common props
+- [[Form Components]] — Button, Input, Select, Checkbox, Toggle, DatePicker, ColorPicker, RichTextEditor, and more
+- [[Layout Components]] — Card, Modal, Tabs, Accordion, Drawer, Dropdown, Grid, Stack, Popover
+- [[Navigation Components]] — Menu, Breadcrumbs, Pagination, Steps, Navbar, Sidebar, SpotlightSearch
+- [[Data Display Components]] — Table, Chart, Calendar, Avatar, Badge, Progress, Stat, Timeline, Carousel, Code, Diff, Sparkline
+- [[Feedback Components]] — Alert, Toast, Loading, Skeleton, EmptyState, ErrorDisplay
+- [[Utility Components]] — Icon, ThemeToggle, Tooltip, Clipboard, Markdown

--- a/docs/Laravel-Inertia-Integration.md
+++ b/docs/Laravel-Inertia-Integration.md
@@ -1,0 +1,363 @@
+# Laravel Inertia Integration
+
+The `@artisanpack-ui/vue-laravel` package provides Inertia.js adapter wrappers, composables, and layout components for seamless integration with Laravel.
+
+## Installation
+
+```bash
+npm install @artisanpack-ui/vue-laravel
+```
+
+### Peer dependencies
+
+- `vue` >= 3.5
+- `@inertiajs/vue3` >= 2.0
+- `@artisanpack-ui/vue` (installed automatically)
+
+## Plugin Setup
+
+Register both the core and Laravel plugins in your `app.ts`:
+
+```ts
+import { createApp, h } from 'vue';
+import { createInertiaApp } from '@inertiajs/vue3';
+import { createArtisanPackUI } from '@artisanpack-ui/vue';
+import { createArtisanPackUILaravel } from '@artisanpack-ui/vue-laravel';
+
+createInertiaApp({
+  resolve: (name) => {
+    const pages = import.meta.glob('./Pages/**/*.vue', { eager: true });
+    return pages[`./Pages/${name}.vue`];
+  },
+  setup({ el, App, props, plugin }) {
+    const app = createApp({ render: () => h(App, props) });
+
+    app.use(plugin);
+    app.use(createArtisanPackUI());
+    app.use(createArtisanPackUILaravel());
+
+    app.mount(el);
+  },
+});
+```
+
+### Plugin options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `prefix` | `string` | `'Ap'` | Prefix for globally registered adapter component names |
+| `flashColorMap` | `Record<string, string>` | See below | Map of flash message keys to toast colors |
+
+## Layout Components
+
+Three layout wrappers are provided for common Laravel page structures:
+
+### AppLayout
+
+Main application layout for authenticated pages:
+
+```vue
+<script setup lang="ts">
+import { AppLayout } from '@artisanpack-ui/vue-laravel';
+</script>
+
+<template>
+  <AppLayout title="Dashboard">
+    <template #header>
+      <h1>Dashboard</h1>
+    </template>
+
+    <p>Page content</p>
+  </AppLayout>
+</template>
+```
+
+### AuthLayout / GuestLayout
+
+```vue
+<script setup lang="ts">
+import { GuestLayout } from '@artisanpack-ui/vue-laravel';
+</script>
+
+<template>
+  <GuestLayout title="Login">
+    <LoginForm />
+  </GuestLayout>
+</template>
+```
+
+## Form Components
+
+Inertia adapter form components automatically bind to Inertia's form state and display server-side validation errors.
+
+### InertiaForm
+
+Wraps child form fields and provides form context via injection:
+
+```vue
+<script setup lang="ts">
+import { InertiaForm, InertiaInput, InertiaSelect } from '@artisanpack-ui/vue-laravel';
+import { useInertiaForm } from '@artisanpack-ui/vue-laravel';
+import { Button } from '@artisanpack-ui/vue';
+
+const { form, processing, post, getError } = useInertiaForm({
+  name: '',
+  email: '',
+  role: '',
+});
+</script>
+
+<template>
+  <InertiaForm @submit.prevent="post('/users')">
+    <InertiaInput label="Name" v-model="form.name" :error="getError('name')" />
+    <InertiaInput label="Email" type="email" v-model="form.email" :error="getError('email')" />
+    <InertiaSelect label="Role" v-model="form.role" :error="getError('role')" :options="roles" />
+
+    <Button type="submit" color="primary" :loading="processing">Save</Button>
+  </InertiaForm>
+</template>
+```
+
+### Available Inertia form components
+
+| Component | Base Component | Description |
+|-----------|---------------|-------------|
+| `InertiaInput` | `Input` | Text input with Inertia error binding |
+| `InertiaSelect` | `Select` | Select dropdown with Inertia error binding |
+| `InertiaTextarea` | `Textarea` | Textarea with Inertia error binding |
+| `InertiaCheckbox` | `Checkbox` | Checkbox with Inertia error binding |
+| `InertiaToggle` | `Toggle` | Toggle switch with Inertia error binding |
+| `InertiaPassword` | `Password` | Password input with Inertia error binding |
+| `InertiaRadio` | `Radio` | Radio group with Inertia error binding |
+
+All Inertia form components accept the same props as their base counterparts plus automatic `error` mapping from Inertia's form state.
+
+## Navigation Components
+
+### InertiaPagination
+
+Renders pagination from a Laravel paginator response using Inertia links:
+
+```vue
+<script setup lang="ts">
+import { InertiaPagination } from '@artisanpack-ui/vue-laravel';
+
+defineProps<{ users: LaravelPaginator<User> }>();
+</script>
+
+<template>
+  <InertiaPagination :paginator="users" />
+</template>
+```
+
+### InertiaBreadcrumbs
+
+Renders breadcrumbs using Inertia's `<Link>` for client-side navigation:
+
+```vue
+<script setup lang="ts">
+import { InertiaBreadcrumbs } from '@artisanpack-ui/vue-laravel';
+
+const items = [
+  { label: 'Home', href: '/' },
+  { label: 'Users', href: '/users' },
+  { label: 'Edit' },
+];
+</script>
+
+<template>
+  <InertiaBreadcrumbs :items="items" />
+</template>
+```
+
+### InertiaMenu
+
+Menu component with Inertia links:
+
+```vue
+<script setup lang="ts">
+import { InertiaMenu } from '@artisanpack-ui/vue-laravel';
+</script>
+
+<template>
+  <InertiaMenu :items="menuItems" />
+</template>
+```
+
+## Composables
+
+### useInertiaForm
+
+Wraps Inertia's `useForm()` with helpers for ArtisanPack UI error display:
+
+```ts
+import { useInertiaForm } from '@artisanpack-ui/vue-laravel';
+
+const { form, errors, processing, recentlySuccessful, isDirty, getError, post, put, patch, destroy, reset, clearErrors } = useInertiaForm({
+  name: '',
+  email: '',
+});
+```
+
+| Return Value | Type | Description |
+|-------------|------|-------------|
+| `form` | `InertiaFormInstance` | The raw Inertia form object |
+| `errors` | `ComputedRef<Record<string, string>>` | Reactive error map |
+| `processing` | `ComputedRef<boolean>` | Whether the form is submitting |
+| `recentlySuccessful` | `ComputedRef<boolean>` | True briefly after successful submission |
+| `isDirty` | `ComputedRef<boolean>` | Whether form data has changed |
+| `getError(field)` | `(field: string) => string \| undefined` | Get error for a specific field |
+| `post(url)` | `(url: string, options?) => void` | Submit via POST |
+| `put(url)` | `(url: string, options?) => void` | Submit via PUT |
+| `patch(url)` | `(url: string, options?) => void` | Submit via PATCH |
+| `destroy(url)` | `(url: string, options?) => void` | Submit via DELETE |
+| `reset(...fields)` | `(...fields: string[]) => void` | Reset form data |
+| `clearErrors(...fields)` | `(...fields: string[]) => void` | Clear validation errors |
+
+Options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `resetOnSuccess` | `boolean` | `true` | Auto-reset form after successful submission |
+
+### useFlashMessages
+
+Watches Inertia page props for flash messages and triggers toasts:
+
+```vue
+<script setup lang="ts">
+import { useFlashMessages } from '@artisanpack-ui/vue-laravel';
+
+// Must be inside a ToastProvider
+useFlashMessages();
+</script>
+```
+
+Flash keys (`success`, `error`, `warning`, `info`, `message`) are mapped to toast colors automatically.
+
+Options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `colorMap` | `Record<string, ToastColor>` | `{ success, error, warning, info, message }` | Custom flash-to-color mapping |
+| `duration` | `number` | `5000` | Toast duration in milliseconds |
+
+### useAuth
+
+Access the authenticated user from Inertia shared props:
+
+```vue
+<script setup lang="ts">
+import { useAuth } from '@artisanpack-ui/vue-laravel';
+
+const { user, isAuthenticated, isGuest } = useAuth();
+</script>
+
+<template>
+  <p v-if="isAuthenticated">Hello, {{ user?.name }}</p>
+  <p v-else>Please sign in.</p>
+</template>
+```
+
+| Return Value | Type | Description |
+|-------------|------|-------------|
+| `user` | `ComputedRef<AuthUser \| null>` | The authenticated user or `null` |
+| `isAuthenticated` | `ComputedRef<boolean>` | `true` when logged in |
+| `isGuest` | `ComputedRef<boolean>` | `true` when not logged in |
+
+Extend the `AuthUser` type for your application:
+
+```ts
+interface AppUser extends AuthUser {
+  avatar_url: string;
+  role: 'admin' | 'user';
+}
+
+const { user } = useAuth<AppUser>();
+```
+
+## Feedback Components
+
+### FlashAlerts
+
+Renders flash messages as inline Alert components:
+
+```vue
+<script setup lang="ts">
+import { FlashAlerts } from '@artisanpack-ui/vue-laravel';
+</script>
+
+<template>
+  <FlashAlerts />
+</template>
+```
+
+### FlashToasts
+
+Renders flash messages as toast notifications (requires `ToastProvider`):
+
+```vue
+<script setup lang="ts">
+import { FlashToasts } from '@artisanpack-ui/vue-laravel';
+</script>
+
+<template>
+  <FlashToasts />
+</template>
+```
+
+## TypeScript Types
+
+Import Laravel-specific types for type-safe page props:
+
+```ts
+import type {
+  LaravelPaginator,
+  LaravelSimplePaginator,
+  PaginationLink,
+  FlashMessages,
+  AuthUser,
+  AuthProps,
+  SharedPageProps,
+} from '@artisanpack-ui/vue-laravel';
+```
+
+### Extending SharedPageProps
+
+```ts
+interface MyPageProps extends SharedPageProps {
+  appName: string;
+  permissions: string[];
+}
+```
+
+## Laravel Backend Setup
+
+### HandleInertiaRequests middleware
+
+Share auth and flash data:
+
+```php
+// app/Http/Middleware/HandleInertiaRequests.php
+public function share(Request $request): array
+{
+    return [
+        ...parent::share($request),
+        'auth' => [
+            'user' => $request->user(),
+        ],
+        'flash' => [
+            'success' => fn () => $request->session()->get('success'),
+            'error' => fn () => $request->session()->get('error'),
+            'warning' => fn () => $request->session()->get('warning'),
+            'info' => fn () => $request->session()->get('info'),
+        ],
+    ];
+}
+```
+
+### Flash messages from controllers
+
+```php
+return redirect()->route('users.index')->with('success', 'User created.');
+```

--- a/docs/Laravel-Inertia-Integration.md
+++ b/docs/Laravel-Inertia-Integration.md
@@ -48,6 +48,18 @@ createInertiaApp({
 | `prefix` | `string` | `'Ap'` | Prefix for globally registered adapter component names |
 | `flashColorMap` | `Record<string, string>` | See below | Map of flash message keys to toast colors |
 
+#### Default flash color map
+
+```ts
+{
+  success: 'success',
+  error: 'error',
+  warning: 'warning',
+  info: 'info',
+  message: 'info',
+}
+```
+
 ## Layout Components
 
 Three layout wrappers are provided for common Laravel page structures:
@@ -188,12 +200,15 @@ import { InertiaMenu } from '@artisanpack-ui/vue-laravel';
 
 ### useInertiaForm
 
-Wraps Inertia's `useForm()` with helpers for ArtisanPack UI error display:
+Wraps Inertia's `useForm()` with helpers for ArtisanPack UI error display. Accepts a generic type parameter `<T>` matching the form data shape:
 
 ```ts
 import { useInertiaForm } from '@artisanpack-ui/vue-laravel';
 
-const { form, errors, processing, recentlySuccessful, isDirty, getError, post, put, patch, destroy, reset, clearErrors } = useInertiaForm({
+const { form, errors, processing, recentlySuccessful, isDirty, getError, post, put, patch, destroy, reset, clearErrors } = useInertiaForm<{
+  name: string;
+  email: string;
+}>({
   name: '',
   email: '',
 });
@@ -201,7 +216,7 @@ const { form, errors, processing, recentlySuccessful, isDirty, getError, post, p
 
 | Return Value | Type | Description |
 |-------------|------|-------------|
-| `form` | `InertiaFormInstance` | The raw Inertia form object |
+| `form` | Inertia form object | The raw Inertia `useForm()` return value |
 | `errors` | `ComputedRef<Record<string, string>>` | Reactive error map |
 | `processing` | `ComputedRef<boolean>` | Whether the form is submitting |
 | `recentlySuccessful` | `ComputedRef<boolean>` | True briefly after successful submission |
@@ -320,6 +335,9 @@ import type {
   AuthProps,
   SharedPageProps,
 } from '@artisanpack-ui/vue-laravel';
+
+// ToastColor is exported from the core package
+import type { ToastColor } from '@artisanpack-ui/vue';
 ```
 
 ### Extending SharedPageProps

--- a/docs/Laravel-Inertia-Integration.md
+++ b/docs/Laravel-Inertia-Integration.md
@@ -46,9 +46,11 @@ createInertiaApp({
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `prefix` | `string` | `'Ap'` | Prefix for globally registered adapter component names |
-| `flashColorMap` | `Record<string, string>` | See below | Map of flash message keys to toast colors |
+| `flashColorMap` | `Record<string, string>` | See below | Declared in the options type but **not yet wired at runtime**. To customize flash-to-color mapping, pass `colorMap` directly to `useFlashMessages()` instead. |
 
-#### Default flash color map
+#### Default flash color map (useFlashMessages)
+
+The default mapping used by `useFlashMessages()`:
 
 ```ts
 {

--- a/docs/Layout-Components.md
+++ b/docs/Layout-Components.md
@@ -1,0 +1,256 @@
+# Layout Components
+
+```ts
+import { Accordion, Card, Collapse, Divider, Drawer, Dropdown, DropdownItem, Grid, Modal, Popover, Stack, Tabs } from '@artisanpack-ui/vue/layout';
+```
+
+---
+
+## Accordion
+
+Container that manages open/close state of child Collapse components. Supports single and multiple open panels.
+
+```vue
+<Accordion>
+  <Collapse title="Section 1">Content 1</Collapse>
+  <Collapse title="Section 2">Content 2</Collapse>
+</Accordion>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `multiple` | `boolean` | `false` | Allow multiple panels open simultaneously |
+| `openIndices` | `number[]` | -- | Controlled mode: currently open panel indices |
+| `defaultOpenIndices` | `number[]` | -- | Uncontrolled mode: initially open panel indices |
+| `join` | `boolean` | `true` | Apply DaisyUI join styling to group panels |
+
+---
+
+## Card
+
+Content container with optional header, footer, figure, and menu slots. Renders as `<a>` when `link` is provided.
+
+```vue
+<Card title="Dashboard" subtitle="Overview">
+  <template #header><h3>Custom Header</h3></template>
+  Content here
+  <template #footer><Button>Action</Button></template>
+</Card>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | -- | Title rendered as `<h2>` |
+| `subtitle` | `string` | -- | Subtitle below the title |
+| `figurePosition` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'top'` | Figure element position |
+| `noShadow` | `boolean` | `false` | Remove card shadow |
+| `bordered` | `boolean` | `false` | Add border |
+| `compact` | `boolean` | `false` | Reduce padding |
+| `glass` | `boolean` | `false` | Glass morphism styling |
+| `link` | `string` | -- | Render as `<a>` with this URL |
+| `external` | `boolean` | `false` | Open link in new tab |
+
+---
+
+## Collapse
+
+Expandable/collapsible content section. Supports controlled (`v-model:open`) and uncontrolled modes.
+
+```vue
+<Collapse title="Details" icon="arrow">
+  Expandable content here.
+</Collapse>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | **required** | Clickable heading text |
+| `icon` | `'arrow' \| 'plus' \| 'none'` | `'arrow'` | Expand/collapse indicator style |
+| `open` | `boolean` | -- | Controlled open state (`v-model:open`) |
+| `defaultOpen` | `boolean` | `false` | Initial open state (uncontrolled) |
+| `name` | `string` | -- | Radio group name for single-open behavior |
+| `bordered` | `boolean` | `false` | Add border |
+| `disabled` | `boolean` | `false` | Disable interaction |
+
+---
+
+## Divider
+
+Visual separator with optional label and color.
+
+```vue
+<Divider />
+<Divider label="OR" color="primary" />
+<Divider vertical />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `vertical` | `boolean` | `false` | Vertical orientation |
+| `color` | `DaisyColor` | -- | Color variant |
+| `label` | `string` | -- | Inline label text |
+| `labelPosition` | `'start' \| 'center' \| 'end'` | `'center'` | Label position |
+
+---
+
+## Drawer
+
+Side panel overlay with focus trapping and keyboard dismissal.
+
+```vue
+<Drawer v-model:open="isOpen" aria-label="Navigation">
+  <nav>Sidebar content</nav>
+</Drawer>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | **required** | Visibility (`v-model:open`) |
+| `end` | `boolean` | `false` | Open from the right side |
+| `persistent` | `boolean` | `false` | Prevent closing via Escape/overlay click |
+| `ariaLabel` | `string` | -- | Accessible label |
+| `ariaLabelledby` | `string` | -- | ID of labelling element |
+
+---
+
+## Dropdown
+
+Trigger + popover menu with keyboard navigation and ARIA semantics.
+
+```vue
+<Dropdown label="Actions">
+  <DropdownItem @click="edit">Edit</DropdownItem>
+  <DropdownItem @click="remove" disabled>Delete</DropdownItem>
+</Dropdown>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | `'Options'` | Trigger button text |
+| `end` | `boolean` | `false` | Align menu to the right |
+| `top` | `boolean` | `false` | Open above the trigger |
+| `hover` | `boolean` | `false` | Open on hover |
+| `open` | `boolean` | -- | Controlled open state (`v-model:open`) |
+
+---
+
+## Grid
+
+CSS grid layout wrapper with responsive column counts and gap controls.
+
+```vue
+<Grid :cols="1" :cols-md="2" :cols-lg="3" :gap="4">
+  <Card>Item 1</Card>
+  <Card>Item 2</Card>
+  <Card>Item 3</Card>
+</Grid>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `cols` | `1-12` | -- | Base column count |
+| `colsSm` | `1-12` | -- | Columns at `sm` breakpoint |
+| `colsMd` | `1-12` | -- | Columns at `md` breakpoint |
+| `colsLg` | `1-12` | -- | Columns at `lg` breakpoint |
+| `colsXl` | `1-12` | -- | Columns at `xl` breakpoint |
+| `gap` | `0-16` | `4` | Uniform gap |
+| `gapX` | `0-16` | -- | Horizontal gap (overrides `gap`) |
+| `gapY` | `0-16` | -- | Vertical gap (overrides `gap`) |
+
+---
+
+## Modal
+
+Dialog overlay with focus trapping, keyboard dismissal, and Teleport rendering.
+
+```vue
+<Modal v-model:open="showModal" title="Confirm Action">
+  <p>Are you sure?</p>
+  <template #actions>
+    <Button @click="showModal = false">Cancel</Button>
+    <Button color="primary" @click="confirm">Confirm</Button>
+  </template>
+</Modal>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | **required** | Visibility (`v-model:open`) |
+| `title` | `string` | -- | Title as `<h3>` |
+| `subtitle` | `string` | -- | Subtitle below title |
+| `persistent` | `boolean` | `false` | Prevent closing via Escape/backdrop |
+| `glass` | `boolean` | `false` | Glass morphism styling |
+| `bottom` | `boolean` | `false` | Bottom sheet on mobile |
+| `ariaLabel` | `string` | -- | Accessible label (when no title) |
+
+---
+
+## Popover
+
+Positioned floating content activated by hover or click.
+
+```vue
+<Popover position="top" trigger-mode="click">
+  <template #trigger><Button>Info</Button></template>
+  <p>Popover content here.</p>
+</Popover>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `triggerMode` | `'hover' \| 'click'` | `'hover'` | Activation mode |
+| `position` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'bottom'` | Position relative to trigger |
+| `showDelay` | `number` | `0` | Show delay in ms (hover mode) |
+| `hideDelay` | `number` | `300` | Hide delay in ms (hover mode) |
+| `open` | `boolean` | -- | Controlled state (`v-model:open`) |
+| `persistent` | `boolean` | `false` | Prevent closing via Escape/click-outside |
+| `ariaLabel` | `string` | -- | Accessible label |
+
+---
+
+## Stack
+
+Flexbox layout wrapper with declarative direction, gap, alignment, and wrap.
+
+```vue
+<Stack direction="horizontal" :gap="4" align="center">
+  <Avatar />
+  <span>Username</span>
+</Stack>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `direction` | `'vertical' \| 'horizontal'` | `'vertical'` | Flex direction |
+| `gap` | `0-16` | `2` | Gap between items |
+| `align` | `'start' \| 'center' \| 'end' \| 'stretch' \| 'baseline'` | -- | Cross-axis alignment |
+| `justify` | `'start' \| 'center' \| 'end' \| 'between' \| 'around' \| 'evenly'` | -- | Main-axis justification |
+| `wrap` | `boolean` | `false` | Allow items to wrap |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Tabs
+
+Tabbed interface with controlled/uncontrolled modes, keyboard navigation, and ARIA semantics.
+
+```vue
+<Tabs :tabs="[
+  { name: 'overview', label: 'Overview' },
+  { name: 'settings', label: 'Settings' },
+]" v-model:active-tab="currentTab">
+  <template #tab-overview>Overview content</template>
+  <template #tab-settings>Settings content</template>
+</Tabs>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `tabs` | `TabItem[]` | **required** | Tab definitions |
+| `activeTab` | `string` | -- | Active tab name (`v-model:activeTab`) |
+| `defaultTab` | `string` | -- | Initial active tab (uncontrolled) |
+| `variant` | `'bordered' \| 'lifted' \| 'boxed'` | `'bordered'` | Tab styling variant |
+| `size` | `Size` | -- | Tab size |
+| `color` | `DaisyColor` | -- | Active tab color |
+
+Dynamic slots named `#tab-{name}` for each tab's content panel.

--- a/docs/Migration-from-Livewire.md
+++ b/docs/Migration-from-Livewire.md
@@ -1,0 +1,199 @@
+# Migration from Livewire
+
+This guide helps you migrate from ArtisanPack UI Livewire components (`artisanpack-ui/livewire-ui-components`) to the Vue equivalents (`@artisanpack-ui/vue`).
+
+## Overview
+
+The Vue components mirror the Livewire component API as closely as possible. The main differences are:
+
+- **Naming**: Blade `<x-artisanpack-button>` becomes Vue `<Button>`
+- **Data binding**: `wire:model` becomes `v-model`
+- **Events**: `wire:click` becomes `@click`
+- **Slots**: Blade named slots (`<x-slot:header>`) become Vue named slots (`<template #header>`)
+- **Server state**: Livewire properties become Vue refs or Inertia form state
+
+## Component Mapping
+
+| Livewire (Blade) | Vue Import | Notes |
+|-------------------|------------|-------|
+| `<x-artisanpack-button>` | `Button` | Same props |
+| `<x-artisanpack-input>` | `Input` | Same props |
+| `<x-artisanpack-select>` | `Select` | Same props |
+| `<x-artisanpack-textarea>` | `Textarea` | Same props |
+| `<x-artisanpack-checkbox>` | `Checkbox` | Same props |
+| `<x-artisanpack-toggle>` | `Toggle` | Same props |
+| `<x-artisanpack-radio>` | `Radio` | Same props |
+| `<x-artisanpack-card>` | `Card` | Same props and slots |
+| `<x-artisanpack-modal>` | `Modal` | `wire:model` becomes `v-model` |
+| `<x-artisanpack-alert>` | `Alert` | Same props |
+| `<x-artisanpack-table>` | `Table` | Different slot API (see below) |
+| `<x-artisanpack-tabs>` | `Tabs` | Props-based API |
+| `<x-artisanpack-badge>` | `Badge` | Same props |
+| `<x-artisanpack-avatar>` | `Avatar` | Same props |
+| `<x-artisanpack-loading>` | `Loading` | Same props |
+| `<x-artisanpack-tooltip>` | `Tooltip` | Same props |
+| `<x-artisanpack-drawer>` | `Drawer` | `wire:model` becomes `v-model` |
+| `<x-artisanpack-dropdown>` | `Dropdown` | Same props |
+| `<x-artisanpack-menu>` | `Menu` | Same props |
+| `<x-artisanpack-breadcrumbs>` | `Breadcrumbs` | Same props |
+| `<x-artisanpack-pagination>` | `Pagination` | Same props |
+| `<x-artisanpack-steps>` | `Steps` | Same props |
+| `<x-artisanpack-progress>` | `Progress` | Same props |
+
+## Common Patterns
+
+### Data binding
+
+```blade
+{{-- Livewire --}}
+<x-artisanpack-input wire:model="name" label="Name" />
+```
+
+```vue
+<!-- Vue -->
+<Input v-model="name" label="Name" />
+```
+
+### Event handling
+
+```blade
+{{-- Livewire --}}
+<x-artisanpack-button wire:click="save" color="primary">Save</x-artisanpack-button>
+```
+
+```vue
+<!-- Vue -->
+<Button @click="save" color="primary">Save</Button>
+```
+
+### Slots
+
+```blade
+{{-- Livewire --}}
+<x-artisanpack-card>
+    <x-slot:header>Title</x-slot:header>
+    Content
+    <x-slot:footer>
+        <x-artisanpack-button>Action</x-artisanpack-button>
+    </x-slot:footer>
+</x-artisanpack-card>
+```
+
+```vue
+<!-- Vue -->
+<Card>
+  <template #header>Title</template>
+  Content
+  <template #footer>
+    <Button>Action</Button>
+  </template>
+</Card>
+```
+
+### Modal state
+
+```blade
+{{-- Livewire --}}
+<x-artisanpack-modal wire:model="showModal" title="Confirm">
+    Are you sure?
+</x-artisanpack-modal>
+```
+
+```vue
+<!-- Vue -->
+<Modal v-model="showModal" title="Confirm">
+  Are you sure?
+</Modal>
+```
+
+### Table
+
+The Table component uses Vue scoped slots instead of Blade's `@scope` directive:
+
+```blade
+{{-- Livewire --}}
+<x-artisanpack-table :headers="$headers" :rows="$users">
+    @scope('cell_name', $user)
+        <strong>{{ $user->name }}</strong>
+    @endscope
+</x-artisanpack-table>
+```
+
+```vue
+<!-- Vue -->
+<Table :columns="columns" :rows="users">
+  <template #cell-name="{ row }">
+    <strong>{{ row.name }}</strong>
+  </template>
+</Table>
+```
+
+### Error handling
+
+```blade
+{{-- Livewire --}}
+<x-artisanpack-input
+    wire:model="email"
+    label="Email"
+    :error="$errors->first('email')"
+/>
+```
+
+```vue
+<!-- Vue with Inertia -->
+<script setup>
+import { useInertiaForm } from '@artisanpack-ui/vue-laravel';
+const { form, getError, post } = useInertiaForm({ email: '' });
+</script>
+
+<InertiaInput v-model="form.email" label="Email" :error="getError('email')" />
+```
+
+### Loading states
+
+```blade
+{{-- Livewire --}}
+<x-artisanpack-button wire:click="save" color="primary">
+    <span wire:loading.remove>Save</span>
+    <span wire:loading>Saving...</span>
+</x-artisanpack-button>
+```
+
+```vue
+<!-- Vue -->
+<Button @click="save" color="primary" :loading="processing">
+  Save
+</Button>
+```
+
+## Step-by-Step Migration
+
+1. **Install Vue packages**: `npm install @artisanpack-ui/vue @artisanpack-ui/vue-laravel`
+2. **Set up Inertia.js** in your Laravel app if not already done
+3. **Register plugins** in your `app.ts` (see [[Laravel Inertia Integration]])
+4. **Convert pages one at a time**: Start with simpler pages (static content, basic forms) before tackling complex interactive pages
+5. **Replace Blade components** with Vue imports using the mapping table above
+6. **Replace `wire:model`** with `v-model`
+7. **Replace `wire:click`** with `@click` and move handler logic to `<script setup>`
+8. **Replace Blade slots** with Vue template slots
+9. **Replace server-side validation** display with `useInertiaForm()` + `getError()`
+10. **Test each page** after conversion
+
+## Props That Changed
+
+Most props are identical between Livewire and Vue versions. Notable differences:
+
+| Prop | Livewire | Vue | Notes |
+|------|----------|-----|-------|
+| `wire:model` | Livewire binding | `v-model` | Standard Vue binding |
+| `error` | `$errors->first('field')` | `getError('field')` | Via `useInertiaForm()` |
+| `icon` (prefix) | `o-icon-name` | Slot-based | Use `#prefix` / `#suffix` slots |
+| Table cell scopes | `@scope('cell_name', $row)` | `#cell-name="{ row }"` | Vue scoped slots |
+
+## What's Not Available (Yet)
+
+Some Livewire-specific features do not have direct Vue equivalents:
+
+- **Real-time validation** via `wire:model.live`: Use `@input` with debounce or watchers
+- **Deferred loading** via `wire:init`: Use Vue's `onMounted` lifecycle hook
+- **Polling** via `wire:poll`: Use `setInterval` in `onMounted`/`onUnmounted`

--- a/docs/Migration-from-Livewire.md
+++ b/docs/Migration-from-Livewire.md
@@ -142,11 +142,14 @@ The Table component uses Vue scoped slots instead of Blade's `@scope` directive:
 ```vue
 <!-- Vue with Inertia -->
 <script setup>
+import { InertiaInput } from '@artisanpack-ui/vue-laravel';
 import { useInertiaForm } from '@artisanpack-ui/vue-laravel';
 const { form, getError, post } = useInertiaForm({ email: '' });
 </script>
 
-<InertiaInput v-model="form.email" label="Email" :error="getError('email')" />
+<template>
+  <InertiaInput name="email" v-model="form.email" label="Email" :error="getError('email')" />
+</template>
 ```
 
 ### Loading states

--- a/docs/Navigation-Components.md
+++ b/docs/Navigation-Components.md
@@ -1,0 +1,182 @@
+# Navigation Components
+
+```ts
+import { Breadcrumbs, Menu, Navbar, Pagination, Sidebar, SpotlightSearch, Steps } from '@artisanpack-ui/vue/navigation';
+```
+
+---
+
+## Breadcrumbs
+
+Navigation breadcrumb trail with semantic markup and ARIA navigation role.
+
+```vue
+<Breadcrumbs :items="[
+  { label: 'Home', href: '/' },
+  { label: 'Products', href: '/products' },
+  { label: 'Widget' },
+]" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `items` | `BreadcrumbItem[]` | **required** | Breadcrumb items (root to current) |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Menu
+
+Vertical or horizontal menu with active state, nested submenus, and keyboard navigation.
+
+```vue
+<Menu :items="[
+  { name: 'home', label: 'Home', href: '/', active: true },
+  { name: 'settings', label: 'Settings', href: '/settings' },
+]" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `items` | `MenuItem[]` | **required** | Menu item definitions |
+| `horizontal` | `boolean` | `false` | Horizontal layout |
+| `size` | `Size` | -- | Menu size |
+| `color` | `DaisyColor` | -- | Active item color |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Navbar
+
+Top navigation bar with start, center, and end slots.
+
+```vue
+<script setup lang="ts">
+import { Navbar, Menu } from '@artisanpack-ui/vue/navigation';
+import { ThemeToggle } from '@artisanpack-ui/vue/utility';
+
+const navItems = [
+  { name: 'home', label: 'Home', href: '/' },
+  { name: 'about', label: 'About', href: '/about' },
+];
+</script>
+
+<template>
+  <Navbar color="primary" glass>
+    <template #start><a href="/">Logo</a></template>
+    <template #center><Menu :items="navItems" horizontal /></template>
+    <template #end><ThemeToggle /></template>
+  </Navbar>
+</template>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `color` | `DaisyColor` | -- | Background color |
+| `glass` | `boolean` | `false` | Glass morphism styling |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Pagination
+
+Page navigation with numbered pages, previous/next buttons, and configurable sibling count.
+
+```vue
+<Pagination :current-page="page" :total-pages="10" @update:current-page="page = $event" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `currentPage` | `number` | **required** | Active page (1-based) |
+| `totalPages` | `number` | **required** | Total number of pages |
+| `siblingCount` | `number` | `1` | Siblings shown on each side of current page |
+| `size` | `Size` | -- | Button size |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Sidebar
+
+Collapsible side navigation panel. Responsive: overlay on mobile, fixed on desktop.
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { Sidebar, Menu } from '@artisanpack-ui/vue/navigation';
+
+const sidebarOpen = ref(false);
+const sidebarItems = [
+  { name: 'dashboard', label: 'Dashboard', href: '/dashboard' },
+  { name: 'settings', label: 'Settings', href: '/settings' },
+];
+</script>
+
+<template>
+  <Sidebar v-model:open="sidebarOpen">
+    <Menu :items="sidebarItems" />
+  </Sidebar>
+</template>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | `false` | Visibility (`v-model:open`) |
+| `side` | `'left' \| 'right'` | `'left'` | Side of the screen |
+| `responsive` | `boolean` | `true` | Always visible on `lg`+ breakpoints |
+| `ariaLabel` | `string` | `'Sidebar navigation'` | Accessible label |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## SpotlightSearch
+
+Command palette / search overlay triggered by Cmd+K / Ctrl+K. Provides keyboard navigation, fuzzy filtering, and grouped results.
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { SpotlightSearch } from '@artisanpack-ui/vue/navigation';
+
+const spotlightOpen = ref(false);
+const commands = [
+  { id: '1', label: 'Go to Dashboard', description: 'Navigate to dashboard', group: 'Navigation' },
+  { id: '2', label: 'Create Post', description: 'Create a new blog post', group: 'Actions' },
+];
+</script>
+
+<template>
+  <SpotlightSearch v-model:open="spotlightOpen" :items="commands" placeholder="Type a command..." />
+</template>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | -- | Visibility (`v-model:open`) |
+| `items` | `SpotlightItem[]` | **required** | Searchable items |
+| `placeholder` | `string` | `'Search...'` | Search input placeholder |
+| `ariaLabel` | `string` | `'Search'` | Accessible label |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Steps
+
+Multi-step progress indicator with color-coded completion states.
+
+```vue
+<Steps :steps="[
+  { label: 'Cart' },
+  { label: 'Shipping' },
+  { label: 'Payment' },
+  { label: 'Confirm' },
+]" :current-step="1" color="primary" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `steps` | `StepItem[]` | **required** | Step definitions |
+| `currentStep` | `number` | -- | Active step index (0-based) |
+| `vertical` | `boolean` | `false` | Vertical layout |
+| `color` | `DaisyColor` | `'primary'` | Color for completed steps |
+| `className` | `string` | -- | Additional CSS classes |

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -1,0 +1,139 @@
+# Theming
+
+ArtisanPack UI for Vue uses DaisyUI themes and a built-in theme provider for light/dark mode management.
+
+## How Theming Works
+
+Components are styled with DaisyUI utility classes, which read color values from the active DaisyUI theme. The active theme is controlled by the `data-theme` attribute on a parent element.
+
+The `provideTheme()` composable manages the current color scheme preference and provides it to the component tree via Vue's dependency injection.
+
+## Setting Up the Theme Provider
+
+Call `provideTheme()` in your root component:
+
+```vue
+<!-- App.vue -->
+<script setup lang="ts">
+import { provideTheme } from '@artisanpack-ui/vue';
+
+const { resolvedColorScheme } = provideTheme();
+</script>
+
+<template>
+  <div :data-theme="resolvedColorScheme">
+    <RouterView />
+  </div>
+</template>
+```
+
+### Default color scheme
+
+Set the default via the plugin:
+
+```ts
+app.use(createArtisanPackUI({
+  defaultColorScheme: 'dark', // 'light' | 'dark' | 'system'
+}));
+```
+
+Or override directly:
+
+```ts
+provideTheme('dark');
+```
+
+Priority order: explicit `provideTheme()` argument > plugin config > `'system'`.
+
+## Consuming the Theme
+
+Any descendant component can read and update the theme:
+
+```vue
+<script setup lang="ts">
+import { useTheme } from '@artisanpack-ui/vue';
+
+const { colorScheme, resolvedColorScheme, setColorScheme } = useTheme();
+</script>
+
+<template>
+  <p>Preference: {{ colorScheme }}</p>
+  <p>Resolved: {{ resolvedColorScheme }}</p>
+
+  <button @click="setColorScheme('light')">Light</button>
+  <button @click="setColorScheme('dark')">Dark</button>
+  <button @click="setColorScheme('system')">System</button>
+</template>
+```
+
+### ThemeToggle component
+
+For a ready-made toggle button:
+
+```vue
+<script setup lang="ts">
+import { ThemeToggle } from '@artisanpack-ui/vue/utility';
+</script>
+
+<template>
+  <ThemeToggle />
+</template>
+```
+
+## DaisyUI Themes
+
+DaisyUI ships with 30+ built-in themes. Enable them in your CSS:
+
+```css
+@plugin "daisyui" {
+  themes: light, dark, cupcake, dracula;
+}
+```
+
+To use a specific DaisyUI theme name instead of `light`/`dark`, set the `data-theme` attribute directly:
+
+```html
+<div data-theme="cupcake">
+  <!-- Components use cupcake colors -->
+</div>
+```
+
+### Custom themes
+
+Define custom themes following the [DaisyUI theme documentation](https://daisyui.com/docs/themes/):
+
+```css
+@plugin "daisyui" {
+  themes: light, dark --default,
+    --custom-brand {
+      primary: oklch(0.72 0.11 178);
+      secondary: oklch(0.65 0.15 280);
+      accent: oklch(0.76 0.18 55);
+    };
+}
+```
+
+## Color Variants
+
+Most components accept a `color` prop using DaisyUI color names:
+
+```vue
+<Button color="primary">Primary</Button>
+<Button color="secondary">Secondary</Button>
+<Button color="accent">Accent</Button>
+<Button color="success">Success</Button>
+<Button color="warning">Warning</Button>
+<Button color="error">Error</Button>
+<Button color="info">Info</Button>
+<Button color="ghost">Ghost</Button>
+```
+
+The `DaisyColor` type includes: `'primary'`, `'secondary'`, `'accent'`, `'neutral'`, `'info'`, `'success'`, `'warning'`, `'error'`. Some components (like Button) also accept `'ghost'` and `'outline'` as additional color variants beyond the base `DaisyColor` type.
+
+## System Preference Detection
+
+When `colorScheme` is set to `'system'`, the theme provider listens to the `prefers-color-scheme` media query and reactively updates `resolvedColorScheme`. Changes to the OS setting are reflected immediately without a page reload.
+
+## Server-Side Rendering
+
+On the server (SSR), `resolvedColorScheme` defaults to `'light'` since `window.matchMedia` is unavailable. After hydration, it resolves to the actual system preference. To avoid a flash of incorrect theme, consider persisting the user's preference in a cookie and reading it server-side.

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -100,16 +100,18 @@ To use a specific DaisyUI theme name instead of `light`/`dark`, set the `data-th
 
 ### Custom themes
 
-Define custom themes following the [DaisyUI theme documentation](https://daisyui.com/docs/themes/):
+Define custom themes using the `@plugin "daisyui/theme"` block following the [DaisyUI theme documentation](https://daisyui.com/docs/themes/):
 
 ```css
 @plugin "daisyui" {
-  themes: light, dark --default,
-    --custom-brand {
-      primary: oklch(0.72 0.11 178);
-      secondary: oklch(0.65 0.15 280);
-      accent: oklch(0.76 0.18 55);
-    };
+  themes: light, dark --default;
+}
+
+@plugin "daisyui/theme" {
+  name: "custom-brand";
+  --color-primary: oklch(0.72 0.11 178);
+  --color-secondary: oklch(0.65 0.15 280);
+  --color-accent: oklch(0.76 0.18 55);
 }
 ```
 

--- a/docs/Utility-Components.md
+++ b/docs/Utility-Components.md
@@ -80,7 +80,7 @@ Toggle control for switching between light, dark, and system color schemes. Inte
 
 ## Tooltip
 
-Positioned tooltip on hover and focus with ARIA `describedby` accessibility.
+Positioned tooltip on hover and focus with ARIA `aria-describedby` accessibility.
 
 ```vue
 <script setup lang="ts">

--- a/docs/Utility-Components.md
+++ b/docs/Utility-Components.md
@@ -1,0 +1,104 @@
+# Utility Components
+
+```ts
+import { Clipboard, Icon, Markdown, ThemeToggle, Tooltip } from '@artisanpack-ui/vue/utility';
+```
+
+---
+
+## Clipboard
+
+Button that copies text to the clipboard with success feedback.
+
+```vue
+<Clipboard text="npm install @artisanpack-ui/vue" label="Copy" success-label="Copied!" color="primary" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `text` | `string` | **required** | Text to copy |
+| `label` | `string` | `'Copy'` | Button label |
+| `successLabel` | `string` | `'Copied!'` | Label after successful copy |
+| `successDuration` | `number` | `2000` | Duration of success state (ms) |
+| `color` | `DaisyColor` | -- | Button color |
+| `size` | `Size` | `'md'` | Button size |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Icon
+
+SVG icon wrapper with configurable size and color. Pass SVG content via the default slot.
+
+```vue
+<Icon size="lg" color="primary" aria-label="Settings">
+  <svg><!-- SVG path --></svg>
+</Icon>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `size` | `Size` | `'md'` | Icon size |
+| `color` | `DaisyColor` | -- | Color variant |
+| `ariaLabel` | `string` | -- | Accessible label (decorative when omitted) |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Markdown
+
+Renders markdown content as HTML with DaisyUI prose typography. Supports headings, bold, italic, links, lists, code blocks, blockquotes, horizontal rules, and images.
+
+```vue
+<Markdown :content="markdownString" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `content` | `string` | **required** | Raw markdown string |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## ThemeToggle
+
+Toggle control for switching between light, dark, and system color schemes. Integrates with `useTheme()` and persists to localStorage.
+
+```vue
+<ThemeToggle />
+<ThemeToggle size="lg" :persist="false" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `size` | `Size` | `'md'` | Toggle size |
+| `persist` | `boolean` | `true` | Persist preference to localStorage |
+| `storageKey` | `string` | `'artisanpack-color-scheme'` | localStorage key |
+| `className` | `string` | -- | Additional CSS classes |
+
+---
+
+## Tooltip
+
+Positioned tooltip on hover and focus with ARIA `describedby` accessibility.
+
+```vue
+<script setup lang="ts">
+import { Tooltip } from '@artisanpack-ui/vue/utility';
+import { Button } from '@artisanpack-ui/vue/form';
+</script>
+
+<template>
+  <Tooltip text="More information" position="top">
+    <Button>Hover me</Button>
+  </Tooltip>
+</template>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `text` | `string` | **required** | Tooltip text |
+| `position` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'top'` | Position relative to trigger |
+| `color` | `DaisyColor` | -- | Color variant |
+| `forceOpen` | `boolean` | `false` | Force tooltip to stay open |
+| `className` | `string` | -- | Additional CSS classes |

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,0 +1,20 @@
+# [[Home]]
+
+## Guides
+
+- [[Getting Started]]
+- [[Design Tokens]]
+- [[Theming]]
+- [[Composables]]
+- [[Laravel Inertia Integration]]
+- [[Migration from Livewire]]
+
+## Components
+
+- [[Component API Reference]]
+- [[Form Components]]
+- [[Layout Components]]
+- [[Navigation Components]]
+- [[Data Display Components]]
+- [[Feedback Components]]
+- [[Utility Components]]


### PR DESCRIPTION
## Description

Add comprehensive documentation for the v1.0.0 release covering both packages (`@artisanpack-ui/vue` and `@artisanpack-ui/vue-laravel`).

**Closes:** #26

## Type of Change

- [x] Documentation update

## Related Issue

**Issue:** #26

## Motivation and Context

Both packages declare MIT license but no root LICENSE file existed. There was no root README, CONTRIBUTING guide, or structured documentation beyond what Histoire stories provide. Inline docs and wiki-ready content are needed before the v1.0.0 public release.

## Changes Made

- Added `LICENSE` (MIT) at repo root
- Added `README.md` with badges, quick start, package overview, and wiki links
- Added `CONTRIBUTING.md` with local dev setup, code style, PR process, and changeset workflow
- Added `CHANGELOG.md` tying the monorepo together
- Added `docs/` directory with 15 wiki-ready markdown files:
  - `Home.md` and `_Sidebar.md` for wiki navigation
  - `Getting-Started.md` — Installation, plugin setup, usage patterns
  - `Design-Tokens.md` — DaisyColor, Size, ColorScheme, FormFieldProps
  - `Theming.md` — ThemeProvider, DaisyUI themes, dark mode
  - `Composables.md` — useTheme, provideTheme, useBreakpoint
  - `Laravel-Inertia-Integration.md` — Full vue-laravel guide
  - `Migration-from-Livewire.md` — Component mapping, pattern conversion
  - `Component-API-Reference.md` — Overview with common props
  - `Form-Components.md` — All 15 form components
  - `Layout-Components.md` — All 12 layout components
  - `Navigation-Components.md` — All 7 navigation components
  - `Data-Display-Components.md` — All 12 data/display components
  - `Feedback-Components.md` — All 6 feedback components + toast system
  - `Utility-Components.md` — All 5 utility components
- Audited inline JSDoc/TSDoc — already comprehensive across all exports

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Node.js: 18+

**Tests Performed:**
1. Ran full test suite (711 tests pass)
2. Ran ESLint (pre-existing warnings only, no new issues)
3. Verified all docs files render correctly as markdown

## Accessibility Tests Run

- [x] N/A — documentation only, no UI changes

## Tests Added

- [x] N/A — documentation only, no code changes

## Documentation

- [x] Inline code documentation added (audited — already complete)
- [x] README updated
- [x] Wiki content ready in docs/ directory
- [x] API documentation updated

**Documentation details:** All 15 docs files use GitHub wiki conventions (Title-Case filenames, `[[Wiki Link]]` syntax, `_Sidebar.md`) and can be copied directly into the wiki repo.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs covering Component API, Form/Layout/Navigation/Data Display/Feedback/Utility components
  * New Getting Started, Theming, Composables, Design Tokens, Migration-from-Livewire, and Laravel/Inertia integration guides
  * Added contributor guide, README, root CHANGELOG, LICENSE, and a structured docs sidebar for easier navigation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->