### PR TITLE
feat(ai): Vue admin components (SettingsPage, UsageDashboard, FeatureToggles)

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -41,6 +41,10 @@
     "./composables": {
       "import": "./dist/composables.mjs",
       "types": "./dist/composables.d.ts"
+    },
+    "./ai": {
+      "import": "./dist/ai.mjs",
+      "types": "./dist/ai.d.ts"
     }
   },
   "files": [

--- a/packages/vue/src/__tests__/ai/FeatureToggles.test.ts
+++ b/packages/vue/src/__tests__/ai/FeatureToggles.test.ts
@@ -66,6 +66,28 @@ describe('FeatureToggles', () => {
     expect((screen.getByLabelText('Toggle Summarize') as HTMLInputElement).checked).toBe(true);
   });
 
+  it('clears a stale error after a subsequent successful toggle', async () => {
+    const toggleFeature = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Boom'))
+      .mockResolvedValueOnce({ feature: { key: 'chat', package: 'core', enabled: true } });
+    const client = createMockClient({
+      getFeatures: vi.fn().mockResolvedValue({ features }),
+      toggleFeature,
+    });
+
+    render(FeatureToggles, { props: { client } });
+
+    const summarizeToggle = await screen.findByLabelText('Toggle Summarize');
+    await fireEvent.click(summarizeToggle);
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('Boom'));
+
+    const chatToggle = screen.getByLabelText('Toggle Chat');
+    await fireEvent.click(chatToggle);
+
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull());
+  });
+
   it('renders empty state when no features are registered', async () => {
     const client = createMockClient({
       getFeatures: vi.fn().mockResolvedValue({ features: [] }),

--- a/packages/vue/src/__tests__/ai/FeatureToggles.test.ts
+++ b/packages/vue/src/__tests__/ai/FeatureToggles.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
+import FeatureToggles from '../../components/ai/FeatureToggles/FeatureToggles.vue';
+import { createMockClient } from './testClient';
+import type { AiFeature } from '../../components/ai/types';
+
+const features: AiFeature[] = [
+  { key: 'summarize', package: 'core', label: 'Summarize', description: 'Short summaries', enabled: true },
+  { key: 'chat', package: 'core', label: 'Chat', description: null, enabled: false },
+];
+
+describe('FeatureToggles', () => {
+  it('renders each registered feature and its enabled state', async () => {
+    const client = createMockClient({
+      getFeatures: vi.fn().mockResolvedValue({ features }),
+    });
+
+    render(FeatureToggles, { props: { client, heading: 'AI Features' } });
+
+    expect(await screen.findByText('Summarize')).toBeTruthy();
+    expect(screen.getByText('Chat')).toBeTruthy();
+
+    const summarizeToggle = screen.getByLabelText('Toggle Summarize') as HTMLInputElement;
+    const chatToggle = screen.getByLabelText('Toggle Chat') as HTMLInputElement;
+    expect(summarizeToggle.checked).toBe(true);
+    expect(chatToggle.checked).toBe(false);
+  });
+
+  it('flips a toggle via POST /features/{key}/toggle and emits toggle', async () => {
+    const toggle = vi.fn().mockResolvedValue({ feature: { key: 'chat', package: 'core', enabled: true } });
+    const client = createMockClient({
+      getFeatures: vi.fn().mockResolvedValue({ features }),
+      toggleFeature: toggle,
+    });
+
+    const { emitted } = render(FeatureToggles, { props: { client } });
+
+    const chatToggle = await screen.findByLabelText('Toggle Chat');
+    await fireEvent.click(chatToggle);
+
+    await waitFor(() => expect(toggle).toHaveBeenCalledWith('chat', true));
+    await waitFor(() => expect(emitted().toggle).toBeTruthy());
+    expect(emitted().toggle[0]).toEqual([{ key: 'chat', package: 'core', enabled: true }]);
+  });
+
+  it('rolls the switch back and surfaces an error when the API rejects', async () => {
+    const client = createMockClient({
+      getFeatures: vi.fn().mockResolvedValue({ features }),
+      toggleFeature: vi.fn().mockRejectedValue(new Error('Boom')),
+    });
+
+    render(FeatureToggles, { props: { client } });
+
+    const summarizeToggle = await screen.findByLabelText('Toggle Summarize');
+    await fireEvent.click(summarizeToggle);
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('Boom'));
+    expect((screen.getByLabelText('Toggle Summarize') as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('renders empty state when no features are registered', async () => {
+    const client = createMockClient({
+      getFeatures: vi.fn().mockResolvedValue({ features: [] }),
+    });
+
+    render(FeatureToggles, { props: { client } });
+
+    expect(await screen.findByText('No AI features registered.')).toBeTruthy();
+  });
+});

--- a/packages/vue/src/__tests__/ai/FeatureToggles.test.ts
+++ b/packages/vue/src/__tests__/ai/FeatureToggles.test.ts
@@ -5,7 +5,13 @@ import { createMockClient } from './testClient';
 import type { AiFeature } from '../../components/ai/types';
 
 const features: AiFeature[] = [
-  { key: 'summarize', package: 'core', label: 'Summarize', description: 'Short summaries', enabled: true },
+  {
+    key: 'summarize',
+    package: 'core',
+    label: 'Summarize',
+    description: 'Short summaries',
+    enabled: true,
+  },
   { key: 'chat', package: 'core', label: 'Chat', description: null, enabled: false },
 ];
 
@@ -27,7 +33,9 @@ describe('FeatureToggles', () => {
   });
 
   it('flips a toggle via POST /features/{key}/toggle and emits toggle', async () => {
-    const toggle = vi.fn().mockResolvedValue({ feature: { key: 'chat', package: 'core', enabled: true } });
+    const toggle = vi
+      .fn()
+      .mockResolvedValue({ feature: { key: 'chat', package: 'core', enabled: true } });
     const client = createMockClient({
       getFeatures: vi.fn().mockResolvedValue({ features }),
       toggleFeature: toggle,

--- a/packages/vue/src/__tests__/ai/SettingsPage.test.ts
+++ b/packages/vue/src/__tests__/ai/SettingsPage.test.ts
@@ -92,4 +92,51 @@ describe('SettingsPage', () => {
 
     expect(await screen.findByText('Connected')).toBeTruthy();
   });
+
+  it('clears the typed api_key and last probe result when switching providers', async () => {
+    const testConnection = vi
+      .fn()
+      .mockResolvedValue({ result: 'ok', message: 'Connected', provider: 'openai' });
+    const client = createMockClient({
+      getSettings: vi.fn().mockResolvedValue(baseResponse),
+      testConnection,
+    });
+
+    render(SettingsPage, { props: { client } });
+    await screen.findByPlaceholderText('gpt-4o-mini');
+
+    const apiKeyInput = screen.getByPlaceholderText('••••••••') as HTMLInputElement;
+    await fireEvent.update(apiKeyInput, 'sk-secret');
+
+    await fireEvent.click(screen.getByRole('button', { name: /Test connection/ }));
+    await screen.findByText('Connected');
+
+    const providerSelect = screen.getByRole('combobox') as HTMLSelectElement;
+    await fireEvent.update(providerSelect, 'ollama');
+
+    expect(screen.queryByPlaceholderText('••••••••')).toBeNull();
+    expect(screen.queryByText('Connected')).toBeNull();
+
+    await fireEvent.click(screen.getByRole('button', { name: /Test connection/ }));
+    const lastCall = testConnection.mock.calls.at(-1)?.[0];
+    expect(lastCall.provider).toBe('ollama');
+    expect(lastCall.api_key).toBeNull();
+  });
+
+  it('renders a network error inside an error alert, not a success alert', async () => {
+    const client = createMockClient({
+      getSettings: vi.fn().mockResolvedValue(baseResponse),
+      updateSettings: vi.fn().mockRejectedValue(new Error('Network down')),
+    });
+
+    render(SettingsPage, { props: { client } });
+    await screen.findByPlaceholderText('gpt-4o-mini');
+
+    await fireEvent.submit(screen.getByTestId('ai-settings-page'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('Network down');
+    expect(alert.className).toContain('alert-error');
+    expect(alert.className).not.toContain('alert-success');
+  });
 });

--- a/packages/vue/src/__tests__/ai/SettingsPage.test.ts
+++ b/packages/vue/src/__tests__/ai/SettingsPage.test.ts
@@ -24,7 +24,9 @@ describe('SettingsPage', () => {
     render(SettingsPage, { props: { client, heading: 'AI Settings' } });
 
     expect(await screen.findByRole('heading', { name: 'AI Settings' })).toBeTruthy();
-    expect((screen.getByPlaceholderText('gpt-4o-mini') as HTMLInputElement).value).toBe('gpt-4o-mini');
+    expect((screen.getByPlaceholderText('gpt-4o-mini') as HTMLInputElement).value).toBe(
+      'gpt-4o-mini',
+    );
     expect(screen.getByText(/leave blank to keep the stored key/)).toBeTruthy();
   });
 
@@ -56,13 +58,15 @@ describe('SettingsPage', () => {
   it('renders per-field validation errors returned from a 422', async () => {
     const client = createMockClient({
       getSettings: vi.fn().mockResolvedValue(baseResponse),
-      updateSettings: vi.fn().mockRejectedValue(
-        new AiApiError(
-          422,
-          { message: 'Validation failed.', errors: { api_key: ['An API key is required.'] } },
-          'Validation failed.',
+      updateSettings: vi
+        .fn()
+        .mockRejectedValue(
+          new AiApiError(
+            422,
+            { message: 'Validation failed.', errors: { api_key: ['An API key is required.'] } },
+            'Validation failed.',
+          ),
         ),
-      ),
     });
 
     render(SettingsPage, { props: { client } });

--- a/packages/vue/src/__tests__/ai/SettingsPage.test.ts
+++ b/packages/vue/src/__tests__/ai/SettingsPage.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
+import SettingsPage from '../../components/ai/SettingsPage/SettingsPage.vue';
+import { AiApiError } from '../../components/ai/createAiApiClient';
+import { createMockClient } from './testClient';
+import type { AiSettingsResponse } from '../../components/ai/types';
+
+const baseResponse: AiSettingsResponse = {
+  credentials: {
+    provider: 'openai',
+    api_key_present: true,
+    base_url: null,
+    default_model: 'gpt-4o-mini',
+  },
+  feature_overrides: [
+    { feature_key: 'summarize', package: 'core', model: null, instructions: null },
+  ],
+};
+
+describe('SettingsPage', () => {
+  it('loads and renders the current settings', async () => {
+    const client = createMockClient({ getSettings: vi.fn().mockResolvedValue(baseResponse) });
+
+    render(SettingsPage, { props: { client, heading: 'AI Settings' } });
+
+    expect(await screen.findByRole('heading', { name: 'AI Settings' })).toBeTruthy();
+    expect((screen.getByPlaceholderText('gpt-4o-mini') as HTMLInputElement).value).toBe('gpt-4o-mini');
+    expect(screen.getByText(/leave blank to keep the stored key/)).toBeTruthy();
+  });
+
+  it('submits the form via PUT /settings and shows a success status', async () => {
+    const update = vi.fn().mockResolvedValue({
+      ...baseResponse,
+      credentials: { ...baseResponse.credentials, default_model: 'gpt-4o' },
+    });
+    const client = createMockClient({
+      getSettings: vi.fn().mockResolvedValue(baseResponse),
+      updateSettings: update,
+    });
+
+    render(SettingsPage, { props: { client } });
+
+    const modelInput = (await screen.findByPlaceholderText('gpt-4o-mini')) as HTMLInputElement;
+    await fireEvent.update(modelInput, 'gpt-4o');
+
+    const form = screen.getByTestId('ai-settings-page');
+    await fireEvent.submit(form);
+
+    await waitFor(() => expect(update).toHaveBeenCalled());
+    const payload = update.mock.calls[0][0];
+    expect(payload.default_model).toBe('gpt-4o');
+    expect(payload.api_key).toBeNull();
+    expect(await screen.findByText('Settings saved.')).toBeTruthy();
+  });
+
+  it('renders per-field validation errors returned from a 422', async () => {
+    const client = createMockClient({
+      getSettings: vi.fn().mockResolvedValue(baseResponse),
+      updateSettings: vi.fn().mockRejectedValue(
+        new AiApiError(
+          422,
+          { message: 'Validation failed.', errors: { api_key: ['An API key is required.'] } },
+          'Validation failed.',
+        ),
+      ),
+    });
+
+    render(SettingsPage, { props: { client } });
+    await screen.findByPlaceholderText('gpt-4o-mini');
+
+    await fireEvent.submit(screen.getByTestId('ai-settings-page'));
+
+    expect(await screen.findByText('An API key is required.')).toBeTruthy();
+  });
+
+  it('probes the provider via test-connection and surfaces the result', async () => {
+    const client = createMockClient({
+      getSettings: vi.fn().mockResolvedValue(baseResponse),
+      testConnection: vi
+        .fn()
+        .mockResolvedValue({ result: 'ok', message: 'Connected', provider: 'openai' }),
+    });
+
+    render(SettingsPage, { props: { client } });
+    await screen.findByPlaceholderText('gpt-4o-mini');
+
+    await fireEvent.click(screen.getByRole('button', { name: /Test connection/ }));
+
+    expect(await screen.findByText('Connected')).toBeTruthy();
+  });
+});

--- a/packages/vue/src/__tests__/ai/UsageDashboard.test.ts
+++ b/packages/vue/src/__tests__/ai/UsageDashboard.test.ts
@@ -65,6 +65,21 @@ describe('UsageDashboard', () => {
     vi.useRealTimers();
   });
 
+  it('reloads when from/to props change', async () => {
+    const getUsage = vi.fn().mockResolvedValue(usage);
+    const client = createMockClient({ getUsage });
+
+    const { rerender } = render(UsageDashboard, { props: { client, from: '2026-07-01' } });
+    await screen.findByText('12');
+    expect(getUsage).toHaveBeenCalledWith({ from: '2026-07-01', to: undefined });
+
+    await rerender({ client, from: '2026-07-15', to: '2026-07-30' });
+
+    await vi.waitFor(() =>
+      expect(getUsage).toHaveBeenLastCalledWith({ from: '2026-07-15', to: '2026-07-30' }),
+    );
+  });
+
   it('surfaces a fetch error when the initial load fails', async () => {
     const client = createMockClient({ getUsage: vi.fn().mockRejectedValue(new Error('Nope')) });
 

--- a/packages/vue/src/__tests__/ai/UsageDashboard.test.ts
+++ b/packages/vue/src/__tests__/ai/UsageDashboard.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/vue';
+import UsageDashboard from '../../components/ai/UsageDashboard/UsageDashboard.vue';
+import { createMockClient } from './testClient';
+import type { AiUsageResponse } from '../../components/ai/types';
+
+const usage: AiUsageResponse = {
+  range: { from: '2026-07-01T00:00:00+00:00', to: '2026-07-31T23:59:59+00:00' },
+  totals: { requests: 12, input_tokens: 1000, output_tokens: 500, total_tokens: 1500, cost: 0.42 },
+  by_feature: [
+    { feature_key: 'summarize', requests: 8, input_tokens: 800, output_tokens: 300, total_tokens: 1100, cost: 0.3 },
+  ],
+  daily: [
+    { period: '2026-07-01', requests: 5, input_tokens: 500, output_tokens: 250, total_tokens: 750, cost: 0.21 },
+  ],
+};
+
+describe('UsageDashboard', () => {
+  it('renders totals, by_feature, and daily buckets from GET /usage', async () => {
+    const client = createMockClient({ getUsage: vi.fn().mockResolvedValue(usage) });
+
+    render(UsageDashboard, { props: { client, heading: 'Usage' } });
+
+    expect(await screen.findByText('Usage')).toBeTruthy();
+    expect(screen.getByText('12')).toBeTruthy();
+    expect(screen.getByText('summarize')).toBeTruthy();
+    expect(screen.getByText('2026-07-01')).toBeTruthy();
+  });
+
+  it('forwards from/to as query params to the API client', async () => {
+    const getUsage = vi.fn().mockResolvedValue(usage);
+    const client = createMockClient({ getUsage });
+
+    render(UsageDashboard, { props: { client, from: '2026-07-01', to: '2026-07-15' } });
+
+    await screen.findByText('12');
+    expect(getUsage).toHaveBeenCalledWith({ from: '2026-07-01', to: '2026-07-15' });
+  });
+
+  it('polls at refreshInterval for live updates', async () => {
+    vi.useFakeTimers();
+    const getUsage = vi.fn().mockResolvedValue(usage);
+    const client = createMockClient({ getUsage });
+
+    render(UsageDashboard, { props: { client, refreshInterval: 1000 } });
+
+    await vi.waitFor(() => expect(getUsage).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(getUsage).toHaveBeenCalledTimes(4);
+
+    vi.useRealTimers();
+  });
+
+  it('surfaces a fetch error when the initial load fails', async () => {
+    const client = createMockClient({ getUsage: vi.fn().mockRejectedValue(new Error('Nope')) });
+
+    render(UsageDashboard, { props: { client } });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('Nope');
+  });
+});

--- a/packages/vue/src/__tests__/ai/UsageDashboard.test.ts
+++ b/packages/vue/src/__tests__/ai/UsageDashboard.test.ts
@@ -8,10 +8,24 @@ const usage: AiUsageResponse = {
   range: { from: '2026-07-01T00:00:00+00:00', to: '2026-07-31T23:59:59+00:00' },
   totals: { requests: 12, input_tokens: 1000, output_tokens: 500, total_tokens: 1500, cost: 0.42 },
   by_feature: [
-    { feature_key: 'summarize', requests: 8, input_tokens: 800, output_tokens: 300, total_tokens: 1100, cost: 0.3 },
+    {
+      feature_key: 'summarize',
+      requests: 8,
+      input_tokens: 800,
+      output_tokens: 300,
+      total_tokens: 1100,
+      cost: 0.3,
+    },
   ],
   daily: [
-    { period: '2026-07-01', requests: 5, input_tokens: 500, output_tokens: 250, total_tokens: 750, cost: 0.21 },
+    {
+      period: '2026-07-01',
+      requests: 5,
+      input_tokens: 500,
+      output_tokens: 250,
+      total_tokens: 750,
+      cost: 0.21,
+    },
   ],
 };
 

--- a/packages/vue/src/__tests__/ai/createAiApiClient.test.ts
+++ b/packages/vue/src/__tests__/ai/createAiApiClient.test.ts
@@ -13,7 +13,15 @@ describe('createAiApiClient', () => {
     const fetchImpl = mockFetch((url) => {
       expect(url).toBe('/api/artisanpack-ai/settings');
       return new Response(
-        JSON.stringify({ credentials: { provider: 'openai', api_key_present: false, base_url: null, default_model: null }, feature_overrides: [] }),
+        JSON.stringify({
+          credentials: {
+            provider: 'openai',
+            api_key_present: false,
+            base_url: null,
+            default_model: null,
+          },
+          feature_overrides: [],
+        }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       );
     });
@@ -38,11 +46,15 @@ describe('createAiApiClient', () => {
   });
 
   it('rejects non-2xx responses with AiApiError including the parsed body', async () => {
-    const fetchImpl = mockFetch(() =>
-      new Response(JSON.stringify({ message: 'Validation failed.', errors: { api_key: ['Required.'] } }), {
-        status: 422,
-        headers: { 'Content-Type': 'application/json' },
-      }),
+    const fetchImpl = mockFetch(
+      () =>
+        new Response(
+          JSON.stringify({ message: 'Validation failed.', errors: { api_key: ['Required.'] } }),
+          {
+            status: 422,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
     );
 
     const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai', fetchImpl });
@@ -64,9 +76,12 @@ describe('createAiApiClient', () => {
     const fetchImpl = mockFetch((url, init) => {
       expect(url).toBe('/api/artisanpack-ai/features/summarize.post/toggle');
       expect(init?.method).toBe('POST');
-      return new Response(JSON.stringify({ feature: { key: 'summarize.post', package: 'core', enabled: true } }), {
-        status: 200,
-      });
+      return new Response(
+        JSON.stringify({ feature: { key: 'summarize.post', package: 'core', enabled: true } }),
+        {
+          status: 200,
+        },
+      );
     });
 
     const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai', fetchImpl });

--- a/packages/vue/src/__tests__/ai/createAiApiClient.test.ts
+++ b/packages/vue/src/__tests__/ai/createAiApiClient.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AiApiError, createAiApiClient } from '../../components/ai/createAiApiClient';
+
+function mockFetch(handler: (input: string, init?: RequestInit) => Response | Promise<Response>) {
+  return vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    return Promise.resolve(handler(url, init));
+  }) as unknown as typeof fetch;
+}
+
+describe('createAiApiClient', () => {
+  it('GETs settings from the configured base URL', async () => {
+    const fetchImpl = mockFetch((url) => {
+      expect(url).toBe('/api/artisanpack-ai/settings');
+      return new Response(
+        JSON.stringify({ credentials: { provider: 'openai', api_key_present: false, base_url: null, default_model: null }, feature_overrides: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+
+    const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai/', fetchImpl });
+    const response = await client.getSettings();
+
+    expect(response.credentials.provider).toBe('openai');
+  });
+
+  it('serializes usage query params', async () => {
+    const fetchImpl = mockFetch((url) => {
+      expect(url).toBe('/api/artisanpack-ai/usage?from=2026-07-01&to=2026-07-31');
+      return new Response(
+        JSON.stringify({ range: { from: '', to: '' }, totals: {}, by_feature: [], daily: [] }),
+        { status: 200 },
+      );
+    });
+
+    const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai', fetchImpl });
+    await client.getUsage({ from: '2026-07-01', to: '2026-07-31' });
+  });
+
+  it('rejects non-2xx responses with AiApiError including the parsed body', async () => {
+    const fetchImpl = mockFetch(() =>
+      new Response(JSON.stringify({ message: 'Validation failed.', errors: { api_key: ['Required.'] } }), {
+        status: 422,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai', fetchImpl });
+
+    await expect(client.updateSettings({ provider: 'openai' })).rejects.toMatchObject({
+      name: 'AiApiError',
+      status: 422,
+    });
+
+    try {
+      await client.updateSettings({ provider: 'openai' });
+    } catch (err) {
+      expect(err).toBeInstanceOf(AiApiError);
+      expect((err as AiApiError).body).toMatchObject({ errors: { api_key: ['Required.'] } });
+    }
+  });
+
+  it('URL-encodes the feature key when toggling', async () => {
+    const fetchImpl = mockFetch((url, init) => {
+      expect(url).toBe('/api/artisanpack-ai/features/summarize.post/toggle');
+      expect(init?.method).toBe('POST');
+      return new Response(JSON.stringify({ feature: { key: 'summarize.post', package: 'core', enabled: true } }), {
+        status: 200,
+      });
+    });
+
+    const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai', fetchImpl });
+    await client.toggleFeature('summarize.post', true);
+  });
+});

--- a/packages/vue/src/__tests__/ai/testClient.ts
+++ b/packages/vue/src/__tests__/ai/testClient.ts
@@ -1,0 +1,14 @@
+import { vi } from 'vitest';
+import type { AiApiClient } from '../../components/ai/types';
+
+export function createMockClient(overrides: Partial<AiApiClient> = {}): AiApiClient {
+  return {
+    getSettings: vi.fn(),
+    updateSettings: vi.fn(),
+    testConnection: vi.fn(),
+    getFeatures: vi.fn(),
+    toggleFeature: vi.fn(),
+    getUsage: vi.fn(),
+    ...overrides,
+  } as AiApiClient;
+}

--- a/packages/vue/src/components/ai/FeatureToggles/FeatureToggles.vue
+++ b/packages/vue/src/components/ai/FeatureToggles/FeatureToggles.vue
@@ -56,38 +56,23 @@ async function handleToggle(feature: AiFeature): Promise<void> {
 </script>
 
 <template>
-  <div
-    v-if="error && !features"
-    role="alert"
-    class="alert alert-error"
-  >
+  <div v-if="error && !features" role="alert" class="alert alert-error">
     <span>{{ error }}</span>
   </div>
 
-  <div
-    v-else-if="!features"
-    class="flex items-center gap-2"
-    role="status"
-    aria-live="polite"
-  >
+  <div v-else-if="!features" class="flex items-center gap-2" role="status" aria-live="polite">
     <span class="loading loading-spinner loading-sm" aria-hidden="true" />
     <span>Loading features…</span>
   </div>
 
-  <div
-    v-else-if="features.length === 0"
-    class="text-sm text-base-content/70"
-    role="status"
-  >
+  <div v-else-if="features.length === 0" class="text-sm text-base-content/70" role="status">
     No AI features registered.
   </div>
 
-  <div
-    v-else
-    class="flex flex-col gap-3"
-    data-testid="ai-feature-toggles"
-  >
-    <h2 v-if="heading" class="text-lg font-semibold">{{ heading }}</h2>
+  <div v-else class="flex flex-col gap-3" data-testid="ai-feature-toggles">
+    <h2 v-if="heading" class="text-lg font-semibold">
+      {{ heading }}
+    </h2>
     <div v-if="error" role="alert" class="alert alert-error">
       <span>{{ error }}</span>
     </div>
@@ -99,10 +84,9 @@ async function handleToggle(feature: AiFeature): Promise<void> {
       >
         <div class="flex flex-col">
           <span class="font-medium">{{ feature.label }}</span>
-          <span
-            v-if="feature.description"
-            class="text-sm text-base-content/70"
-          >{{ feature.description }}</span>
+          <span v-if="feature.description" class="text-sm text-base-content/70">{{
+            feature.description
+          }}</span>
           <span class="text-xs uppercase tracking-wide text-base-content/50">
             {{ feature.package }} · {{ feature.key }}
           </span>
@@ -118,7 +102,7 @@ async function handleToggle(feature: AiFeature): Promise<void> {
             :disabled="pending[feature.key] === true"
             :aria-label="`Toggle ${feature.label}`"
             @change="handleToggle(feature)"
-          >
+          />
         </label>
       </li>
     </ul>

--- a/packages/vue/src/components/ai/FeatureToggles/FeatureToggles.vue
+++ b/packages/vue/src/components/ai/FeatureToggles/FeatureToggles.vue
@@ -40,6 +40,7 @@ async function handleToggle(feature: AiFeature): Promise<void> {
 
   try {
     const response = await props.client.toggleFeature(feature.key, target);
+    error.value = null;
     emit('toggle', response.feature);
   } catch (err) {
     // Roll back on failure
@@ -56,55 +57,58 @@ async function handleToggle(feature: AiFeature): Promise<void> {
 </script>
 
 <template>
-  <div v-if="error && !features" role="alert" class="alert alert-error">
-    <span>{{ error }}</span>
-  </div>
-
-  <div v-else-if="!features" class="flex items-center gap-2" role="status" aria-live="polite">
-    <span class="loading loading-spinner loading-sm" aria-hidden="true" />
-    <span>Loading features…</span>
-  </div>
-
-  <div v-else-if="features.length === 0" class="text-sm text-base-content/70" role="status">
-    No AI features registered.
-  </div>
-
-  <div v-else class="flex flex-col gap-3" data-testid="ai-feature-toggles">
+  <div class="flex flex-col gap-3" data-testid="ai-feature-toggles">
     <h2 v-if="heading" class="text-lg font-semibold">
       {{ heading }}
     </h2>
-    <div v-if="error" role="alert" class="alert alert-error">
+
+    <div v-if="error && !features" role="alert" class="alert alert-error">
       <span>{{ error }}</span>
     </div>
-    <ul class="flex flex-col gap-2">
-      <li
-        v-for="feature in features"
-        :key="feature.key"
-        class="flex items-center justify-between gap-4 rounded-box border border-base-300 p-3"
-      >
-        <div class="flex flex-col">
-          <span class="font-medium">{{ feature.label }}</span>
-          <span v-if="feature.description" class="text-sm text-base-content/70">{{
-            feature.description
-          }}</span>
-          <span class="text-xs uppercase tracking-wide text-base-content/50">
-            {{ feature.package }} · {{ feature.key }}
-          </span>
-        </div>
-        <label class="cursor-pointer">
-          <span class="sr-only">
-            {{ feature.enabled ? 'Disable' : 'Enable' }} {{ feature.label }}
-          </span>
-          <input
-            type="checkbox"
-            class="toggle toggle-primary"
-            :checked="feature.enabled"
-            :disabled="pending[feature.key] === true"
-            :aria-label="`Toggle ${feature.label}`"
-            @change="handleToggle(feature)"
-          />
-        </label>
-      </li>
-    </ul>
+
+    <div v-else-if="!features" class="flex items-center gap-2" role="status" aria-live="polite">
+      <span class="loading loading-spinner loading-sm" aria-hidden="true" />
+      <span>Loading features…</span>
+    </div>
+
+    <div v-else-if="features.length === 0" class="text-sm text-base-content/70" role="status">
+      No AI features registered.
+    </div>
+
+    <template v-else>
+      <div v-if="error" role="alert" class="alert alert-error">
+        <span>{{ error }}</span>
+      </div>
+      <ul class="flex flex-col gap-2">
+        <li
+          v-for="feature in features"
+          :key="feature.key"
+          class="flex items-center justify-between gap-4 rounded-box border border-base-300 p-3"
+        >
+          <div class="flex flex-col">
+            <span class="font-medium">{{ feature.label }}</span>
+            <span v-if="feature.description" class="text-sm text-base-content/70">{{
+              feature.description
+            }}</span>
+            <span class="text-xs uppercase tracking-wide text-base-content/50">
+              {{ feature.package }} · {{ feature.key }}
+            </span>
+          </div>
+          <label class="cursor-pointer">
+            <span class="sr-only">
+              {{ feature.enabled ? 'Disable' : 'Enable' }} {{ feature.label }}
+            </span>
+            <input
+              type="checkbox"
+              class="toggle toggle-primary"
+              :checked="feature.enabled"
+              :disabled="pending[feature.key] === true"
+              :aria-label="`Toggle ${feature.label}`"
+              @change="handleToggle(feature)"
+            />
+          </label>
+        </li>
+      </ul>
+    </template>
   </div>
 </template>

--- a/packages/vue/src/components/ai/FeatureToggles/FeatureToggles.vue
+++ b/packages/vue/src/components/ai/FeatureToggles/FeatureToggles.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+/** @module ai/FeatureToggles */
+import { onMounted, reactive, ref } from 'vue';
+import type { AiApiClient, AiFeature } from '../types';
+
+interface Props {
+  /** API client wrapping the artisanpack-ui/ai JSON endpoints. */
+  client: AiApiClient;
+  /** Optional heading rendered above the list. */
+  heading?: string;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<{
+  toggle: [feature: Pick<AiFeature, 'key' | 'package' | 'enabled'>];
+}>();
+
+const features = ref<AiFeature[] | null>(null);
+const error = ref<string | null>(null);
+const pending = reactive<Record<string, boolean>>({});
+
+onMounted(async () => {
+  try {
+    const response = await props.client.getFeatures();
+    features.value = response.features;
+  } catch (err) {
+    error.value = (err as Error).message;
+  }
+});
+
+async function handleToggle(feature: AiFeature): Promise<void> {
+  const target = !feature.enabled;
+  pending[feature.key] = true;
+  // Optimistic flip
+  if (features.value) {
+    features.value = features.value.map((f) =>
+      f.key === feature.key ? { ...f, enabled: target } : f,
+    );
+  }
+
+  try {
+    const response = await props.client.toggleFeature(feature.key, target);
+    emit('toggle', response.feature);
+  } catch (err) {
+    // Roll back on failure
+    if (features.value) {
+      features.value = features.value.map((f) =>
+        f.key === feature.key ? { ...f, enabled: feature.enabled } : f,
+      );
+    }
+    error.value = (err as Error).message;
+  } finally {
+    delete pending[feature.key];
+  }
+}
+</script>
+
+<template>
+  <div
+    v-if="error && !features"
+    role="alert"
+    class="alert alert-error"
+  >
+    <span>{{ error }}</span>
+  </div>
+
+  <div
+    v-else-if="!features"
+    class="flex items-center gap-2"
+    role="status"
+    aria-live="polite"
+  >
+    <span class="loading loading-spinner loading-sm" aria-hidden="true" />
+    <span>Loading features…</span>
+  </div>
+
+  <div
+    v-else-if="features.length === 0"
+    class="text-sm text-base-content/70"
+    role="status"
+  >
+    No AI features registered.
+  </div>
+
+  <div
+    v-else
+    class="flex flex-col gap-3"
+    data-testid="ai-feature-toggles"
+  >
+    <h2 v-if="heading" class="text-lg font-semibold">{{ heading }}</h2>
+    <div v-if="error" role="alert" class="alert alert-error">
+      <span>{{ error }}</span>
+    </div>
+    <ul class="flex flex-col gap-2">
+      <li
+        v-for="feature in features"
+        :key="feature.key"
+        class="flex items-center justify-between gap-4 rounded-box border border-base-300 p-3"
+      >
+        <div class="flex flex-col">
+          <span class="font-medium">{{ feature.label }}</span>
+          <span
+            v-if="feature.description"
+            class="text-sm text-base-content/70"
+          >{{ feature.description }}</span>
+          <span class="text-xs uppercase tracking-wide text-base-content/50">
+            {{ feature.package }} · {{ feature.key }}
+          </span>
+        </div>
+        <label class="cursor-pointer">
+          <span class="sr-only">
+            {{ feature.enabled ? 'Disable' : 'Enable' }} {{ feature.label }}
+          </span>
+          <input
+            type="checkbox"
+            class="toggle toggle-primary"
+            :checked="feature.enabled"
+            :disabled="pending[feature.key] === true"
+            :aria-label="`Toggle ${feature.label}`"
+            @change="handleToggle(feature)"
+          >
+        </label>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/packages/vue/src/components/ai/SettingsPage/SettingsPage.vue
+++ b/packages/vue/src/components/ai/SettingsPage/SettingsPage.vue
@@ -1,0 +1,288 @@
+<script setup lang="ts">
+/** @module ai/SettingsPage */
+import { computed, onMounted, reactive, ref } from 'vue';
+import type {
+  AiApiClient,
+  AiConnectionTestResult,
+  AiFeatureOverride,
+  AiSettingsResponse,
+  AiSettingsUpdate,
+} from '../types';
+import { AiApiError } from '../createAiApiClient';
+
+interface Props {
+  /** API client wrapping the artisanpack-ui/ai JSON endpoints. */
+  client: AiApiClient;
+  /** Provider IDs shown in the provider dropdown. */
+  providers?: string[];
+  /** Optional heading rendered above the form. */
+  heading?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  providers: () => ['openai', 'anthropic', 'ollama'],
+  heading: undefined,
+});
+
+interface FormState {
+  provider: string;
+  api_key: string;
+  base_url: string;
+  default_model: string;
+  overrides: AiFeatureOverride[];
+}
+
+const emptyForm: FormState = {
+  provider: 'openai',
+  api_key: '',
+  base_url: '',
+  default_model: '',
+  overrides: [],
+};
+
+const initial = ref<AiSettingsResponse | null>(null);
+const form = reactive<FormState>({ ...emptyForm });
+const loading = ref(true);
+const saving = ref(false);
+const testing = ref(false);
+const errors = ref<Record<string, string[]>>({});
+const status = ref<string | null>(null);
+const testResult = ref<AiConnectionTestResult | null>(null);
+
+function toFormState(response: AiSettingsResponse): void {
+  form.provider = response.credentials.provider;
+  form.api_key = '';
+  form.base_url = response.credentials.base_url ?? '';
+  form.default_model = response.credentials.default_model ?? '';
+  form.overrides = response.feature_overrides.map((o) => ({ ...o }));
+}
+
+function toUpdatePayload(): AiSettingsUpdate {
+  return {
+    provider: form.provider,
+    api_key: form.api_key === '' ? null : form.api_key,
+    base_url: form.base_url === '' ? null : form.base_url,
+    default_model: form.default_model === '' ? null : form.default_model,
+    feature_overrides: form.overrides.map((override) => ({
+      feature_key: override.feature_key,
+      model: override.model,
+      instructions: override.instructions,
+    })),
+  };
+}
+
+const apiKeyPresent = computed(() => initial.value?.credentials.api_key_present ?? false);
+const isOllama = computed(() => form.provider === 'ollama');
+
+onMounted(async () => {
+  loading.value = true;
+  try {
+    const response = await props.client.getSettings();
+    initial.value = response;
+    toFormState(response);
+  } catch (err) {
+    status.value = (err as Error).message;
+  } finally {
+    loading.value = false;
+  }
+});
+
+async function handleSubmit(): Promise<void> {
+  saving.value = true;
+  errors.value = {};
+  status.value = null;
+  try {
+    const response = await props.client.updateSettings(toUpdatePayload());
+    initial.value = response;
+    toFormState(response);
+    status.value = 'Settings saved.';
+  } catch (err) {
+    if (err instanceof AiApiError && err.status === 422) {
+      const body = err.body as { errors?: Record<string, string[]>; message?: string };
+      errors.value = body?.errors ?? {};
+      status.value = body?.message ?? err.message;
+    } else {
+      status.value = (err as Error).message;
+    }
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function handleTest(): Promise<void> {
+  testing.value = true;
+  testResult.value = null;
+  try {
+    testResult.value = await props.client.testConnection({
+      provider: form.provider,
+      api_key: form.api_key === '' ? null : form.api_key,
+      base_url: form.base_url === '' ? null : form.base_url,
+      default_model: form.default_model === '' ? null : form.default_model,
+    });
+  } catch (err) {
+    if (err instanceof AiApiError) {
+      testResult.value = (err.body as AiConnectionTestResult | null) ?? {
+        result: 'error',
+        message: err.message,
+      };
+    } else {
+      testResult.value = { result: 'error', message: (err as Error).message };
+    }
+  } finally {
+    testing.value = false;
+  }
+}
+</script>
+
+<template>
+  <div
+    v-if="loading"
+    class="flex items-center gap-2"
+    role="status"
+    aria-live="polite"
+  >
+    <span class="loading loading-spinner loading-sm" aria-hidden="true" />
+    <span>Loading AI settings…</span>
+  </div>
+
+  <form
+    v-else
+    class="flex flex-col gap-6"
+    data-testid="ai-settings-page"
+    novalidate
+    @submit.prevent="handleSubmit"
+  >
+    <h2 v-if="heading" class="text-lg font-semibold">{{ heading }}</h2>
+
+    <div
+      v-if="status"
+      role="status"
+      aria-live="polite"
+      :class="Object.keys(errors).length > 0 ? 'alert alert-error' : 'alert alert-success'"
+    >
+      <span>{{ status }}</span>
+    </div>
+
+    <fieldset class="flex flex-col gap-3">
+      <legend class="text-base font-medium">Credentials</legend>
+
+      <label class="form-control flex flex-col gap-1">
+        <span class="label-text">Provider</span>
+        <select v-model="form.provider" class="select select-bordered">
+          <option v-for="provider in props.providers" :key="provider" :value="provider">
+            {{ provider }}
+          </option>
+        </select>
+        <span
+          v-for="message in errors.provider"
+          :key="message"
+          class="label-text-alt text-error"
+        >{{ message }}</span>
+      </label>
+
+      <label v-if="!isOllama" class="form-control flex flex-col gap-1">
+        <span class="label-text">
+          API key <span v-if="apiKeyPresent">(leave blank to keep the stored key)</span>
+        </span>
+        <input
+          v-model="form.api_key"
+          type="password"
+          autocomplete="off"
+          class="input input-bordered"
+          :placeholder="apiKeyPresent ? '••••••••' : 'sk-…'"
+        >
+        <span
+          v-for="message in errors.api_key"
+          :key="message"
+          class="label-text-alt text-error"
+        >{{ message }}</span>
+      </label>
+
+      <label class="form-control flex flex-col gap-1">
+        <span class="label-text">
+          Base URL <span v-if="isOllama">(required)</span><span v-else>(optional)</span>
+        </span>
+        <input
+          v-model="form.base_url"
+          type="url"
+          class="input input-bordered"
+          :placeholder="isOllama ? 'http://localhost:11434' : 'https://api.example.com/v1'"
+        >
+        <span
+          v-for="message in errors.base_url"
+          :key="message"
+          class="label-text-alt text-error"
+        >{{ message }}</span>
+      </label>
+
+      <label class="form-control flex flex-col gap-1">
+        <span class="label-text">Default model</span>
+        <input
+          v-model="form.default_model"
+          type="text"
+          class="input input-bordered"
+          placeholder="gpt-4o-mini"
+        >
+        <span
+          v-for="message in errors.default_model"
+          :key="message"
+          class="label-text-alt text-error"
+        >{{ message }}</span>
+      </label>
+
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          class="btn btn-outline btn-sm"
+          :disabled="testing"
+          @click="handleTest"
+        >
+          {{ testing ? 'Testing…' : 'Test connection' }}
+        </button>
+        <span
+          v-if="testResult"
+          role="status"
+          :class="testResult.result === 'ok' ? 'text-sm text-success' : 'text-sm text-error'"
+        >
+          {{ testResult.message ?? (testResult.result === 'ok' ? 'OK' : 'Failed') }}
+        </span>
+      </div>
+    </fieldset>
+
+    <fieldset v-if="form.overrides.length > 0" class="flex flex-col gap-3">
+      <legend class="text-base font-medium">Per-feature overrides</legend>
+      <div
+        v-for="(override, index) in form.overrides"
+        :key="override.feature_key"
+        class="rounded-box border border-base-300 p-3"
+      >
+        <div class="text-sm font-medium">
+          {{ override.package }} · {{ override.feature_key }}
+        </div>
+        <label class="form-control mt-2 flex flex-col gap-1">
+          <span class="label-text">Model</span>
+          <input
+            v-model="form.overrides[index].model"
+            type="text"
+            class="input input-bordered input-sm"
+            placeholder="inherit default"
+          >
+        </label>
+        <label class="form-control mt-2 flex flex-col gap-1">
+          <span class="label-text">Instructions</span>
+          <textarea
+            v-model="form.overrides[index].instructions"
+            class="textarea textarea-bordered"
+            rows="3"
+          />
+        </label>
+      </div>
+    </fieldset>
+
+    <div class="flex justify-end">
+      <button type="submit" class="btn btn-primary" :disabled="saving">
+        {{ saving ? 'Saving…' : 'Save settings' }}
+      </button>
+    </div>
+  </form>
+</template>

--- a/packages/vue/src/components/ai/SettingsPage/SettingsPage.vue
+++ b/packages/vue/src/components/ai/SettingsPage/SettingsPage.vue
@@ -47,6 +47,7 @@ const saving = ref(false);
 const testing = ref(false);
 const errors = ref<Record<string, string[]>>({});
 const status = ref<string | null>(null);
+const statusVariant = ref<'success' | 'error'>('success');
 const testResult = ref<AiConnectionTestResult | null>(null);
 
 function toFormState(response: AiSettingsResponse): void {
@@ -82,10 +83,19 @@ onMounted(async () => {
     toFormState(response);
   } catch (err) {
     status.value = (err as Error).message;
+    statusVariant.value = 'error';
   } finally {
     loading.value = false;
   }
 });
+
+function handleProviderChange(provider: string): void {
+  // Reset the typed key + last probe result so we don't silently ship
+  // an OpenAI key to an Ollama base URL (or the other way around).
+  form.provider = provider;
+  form.api_key = '';
+  testResult.value = null;
+}
 
 async function handleSubmit(): Promise<void> {
   saving.value = true;
@@ -96,7 +106,9 @@ async function handleSubmit(): Promise<void> {
     initial.value = response;
     toFormState(response);
     status.value = 'Settings saved.';
+    statusVariant.value = 'success';
   } catch (err) {
+    statusVariant.value = 'error';
     if (err instanceof AiApiError && err.status === 422) {
       const body = err.body as { errors?: Record<string, string[]>; message?: string };
       errors.value = body?.errors ?? {};
@@ -153,9 +165,9 @@ async function handleTest(): Promise<void> {
 
     <div
       v-if="status"
-      role="status"
+      :role="statusVariant === 'error' ? 'alert' : 'status'"
       aria-live="polite"
-      :class="Object.keys(errors).length > 0 ? 'alert alert-error' : 'alert alert-success'"
+      :class="statusVariant === 'error' ? 'alert alert-error' : 'alert alert-success'"
     >
       <span>{{ status }}</span>
     </div>
@@ -165,7 +177,11 @@ async function handleTest(): Promise<void> {
 
       <label class="form-control flex flex-col gap-1">
         <span class="label-text">Provider</span>
-        <select v-model="form.provider" class="select select-bordered">
+        <select
+          :value="form.provider"
+          class="select select-bordered"
+          @change="handleProviderChange(($event.target as HTMLSelectElement).value)"
+        >
           <option v-for="provider in props.providers" :key="provider" :value="provider">
             {{ provider }}
           </option>

--- a/packages/vue/src/components/ai/SettingsPage/SettingsPage.vue
+++ b/packages/vue/src/components/ai/SettingsPage/SettingsPage.vue
@@ -135,12 +135,7 @@ async function handleTest(): Promise<void> {
 </script>
 
 <template>
-  <div
-    v-if="loading"
-    class="flex items-center gap-2"
-    role="status"
-    aria-live="polite"
-  >
+  <div v-if="loading" class="flex items-center gap-2" role="status" aria-live="polite">
     <span class="loading loading-spinner loading-sm" aria-hidden="true" />
     <span>Loading AI settings…</span>
   </div>
@@ -152,7 +147,9 @@ async function handleTest(): Promise<void> {
     novalidate
     @submit.prevent="handleSubmit"
   >
-    <h2 v-if="heading" class="text-lg font-semibold">{{ heading }}</h2>
+    <h2 v-if="heading" class="text-lg font-semibold">
+      {{ heading }}
+    </h2>
 
     <div
       v-if="status"
@@ -173,11 +170,9 @@ async function handleTest(): Promise<void> {
             {{ provider }}
           </option>
         </select>
-        <span
-          v-for="message in errors.provider"
-          :key="message"
-          class="label-text-alt text-error"
-        >{{ message }}</span>
+        <span v-for="message in errors.provider" :key="message" class="label-text-alt text-error">{{
+          message
+        }}</span>
       </label>
 
       <label v-if="!isOllama" class="form-control flex flex-col gap-1">
@@ -190,12 +185,10 @@ async function handleTest(): Promise<void> {
           autocomplete="off"
           class="input input-bordered"
           :placeholder="apiKeyPresent ? '••••••••' : 'sk-…'"
-        >
-        <span
-          v-for="message in errors.api_key"
-          :key="message"
-          class="label-text-alt text-error"
-        >{{ message }}</span>
+        />
+        <span v-for="message in errors.api_key" :key="message" class="label-text-alt text-error">{{
+          message
+        }}</span>
       </label>
 
       <label class="form-control flex flex-col gap-1">
@@ -207,12 +200,10 @@ async function handleTest(): Promise<void> {
           type="url"
           class="input input-bordered"
           :placeholder="isOllama ? 'http://localhost:11434' : 'https://api.example.com/v1'"
-        >
-        <span
-          v-for="message in errors.base_url"
-          :key="message"
-          class="label-text-alt text-error"
-        >{{ message }}</span>
+        />
+        <span v-for="message in errors.base_url" :key="message" class="label-text-alt text-error">{{
+          message
+        }}</span>
       </label>
 
       <label class="form-control flex flex-col gap-1">
@@ -222,12 +213,13 @@ async function handleTest(): Promise<void> {
           type="text"
           class="input input-bordered"
           placeholder="gpt-4o-mini"
-        >
+        />
         <span
           v-for="message in errors.default_model"
           :key="message"
           class="label-text-alt text-error"
-        >{{ message }}</span>
+          >{{ message }}</span
+        >
       </label>
 
       <div class="flex items-center gap-2">
@@ -256,9 +248,7 @@ async function handleTest(): Promise<void> {
         :key="override.feature_key"
         class="rounded-box border border-base-300 p-3"
       >
-        <div class="text-sm font-medium">
-          {{ override.package }} · {{ override.feature_key }}
-        </div>
+        <div class="text-sm font-medium">{{ override.package }} · {{ override.feature_key }}</div>
         <label class="form-control mt-2 flex flex-col gap-1">
           <span class="label-text">Model</span>
           <input
@@ -266,7 +256,7 @@ async function handleTest(): Promise<void> {
             type="text"
             class="input input-bordered input-sm"
             placeholder="inherit default"
-          >
+          />
         </label>
         <label class="form-control mt-2 flex flex-col gap-1">
           <span class="label-text">Instructions</span>

--- a/packages/vue/src/components/ai/UsageDashboard/UsageDashboard.vue
+++ b/packages/vue/src/components/ai/UsageDashboard/UsageDashboard.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+/** @module ai/UsageDashboard */
+import { onMounted, onScopeDispose, ref, watch } from 'vue';
+import type { AiApiClient, AiUsageResponse } from '../types';
+
+interface Props {
+  /** API client wrapping the artisanpack-ui/ai JSON endpoints. */
+  client: AiApiClient;
+  /** Optional `from` date (YYYY-MM-DD) passed as a query param. */
+  from?: string;
+  /** Optional `to` date (YYYY-MM-DD) passed as a query param. */
+  to?: string;
+  /**
+   * Poll interval in milliseconds for live updates. Defaults to `0` (no polling).
+   */
+  refreshInterval?: number;
+  /** Optional heading rendered above the dashboard. */
+  heading?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  from: undefined,
+  to: undefined,
+  refreshInterval: 0,
+  heading: undefined,
+});
+
+const usage = ref<AiUsageResponse | null>(null);
+const loading = ref(true);
+const error = ref<string | null>(null);
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+const formatNumber = (value: number): string => new Intl.NumberFormat().format(value);
+const formatCost = (value: number): string =>
+  new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  }).format(value);
+
+async function load(): Promise<void> {
+  try {
+    const response = await props.client.getUsage({ from: props.from, to: props.to });
+    usage.value = response;
+    error.value = null;
+  } catch (err) {
+    error.value = (err as Error).message;
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  load();
+});
+
+watch(
+  () => props.refreshInterval,
+  (interval) => {
+    if (intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+    if (interval > 0) {
+      intervalId = setInterval(load, interval);
+    }
+  },
+  { immediate: true },
+);
+
+onScopeDispose(() => {
+  if (intervalId !== null) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+});
+</script>
+
+<template>
+  <div
+    v-if="loading && !usage"
+    class="flex items-center gap-2"
+    role="status"
+    aria-live="polite"
+  >
+    <span class="loading loading-spinner loading-sm" aria-hidden="true" />
+    <span>Loading usage…</span>
+  </div>
+
+  <div v-else-if="error && !usage" role="alert" class="alert alert-error">
+    <span>{{ error }}</span>
+  </div>
+
+  <div
+    v-else-if="usage"
+    class="flex flex-col gap-6"
+    data-testid="ai-usage-dashboard"
+  >
+    <h2 v-if="heading" class="text-lg font-semibold">{{ heading }}</h2>
+
+    <div class="stats stats-vertical sm:stats-horizontal shadow">
+      <div class="stat">
+        <div class="stat-title">Requests</div>
+        <div class="stat-value">{{ formatNumber(usage.totals.requests) }}</div>
+      </div>
+      <div class="stat">
+        <div class="stat-title">Input tokens</div>
+        <div class="stat-value">{{ formatNumber(usage.totals.input_tokens) }}</div>
+      </div>
+      <div class="stat">
+        <div class="stat-title">Output tokens</div>
+        <div class="stat-value">{{ formatNumber(usage.totals.output_tokens) }}</div>
+      </div>
+      <div class="stat">
+        <div class="stat-title">Cost</div>
+        <div class="stat-value">{{ formatCost(usage.totals.cost) }}</div>
+      </div>
+    </div>
+
+    <section aria-labelledby="ai-usage-by-feature">
+      <h3 id="ai-usage-by-feature" class="mb-2 font-medium">By feature</h3>
+      <p
+        v-if="usage.by_feature.length === 0"
+        class="text-sm text-base-content/70"
+      >No feature usage in this range.</p>
+      <div v-else class="overflow-x-auto">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>Feature</th>
+              <th class="text-right">Requests</th>
+              <th class="text-right">Input</th>
+              <th class="text-right">Output</th>
+              <th class="text-right">Cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in usage.by_feature" :key="row.feature_key">
+              <td>{{ row.feature_key }}</td>
+              <td class="text-right">{{ formatNumber(row.requests) }}</td>
+              <td class="text-right">{{ formatNumber(row.input_tokens) }}</td>
+              <td class="text-right">{{ formatNumber(row.output_tokens) }}</td>
+              <td class="text-right">{{ formatCost(row.cost) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section aria-labelledby="ai-usage-daily">
+      <h3 id="ai-usage-daily" class="mb-2 font-medium">Daily</h3>
+      <p
+        v-if="usage.daily.length === 0"
+        class="text-sm text-base-content/70"
+      >No daily usage in this range.</p>
+      <div v-else class="overflow-x-auto">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>Day</th>
+              <th class="text-right">Requests</th>
+              <th class="text-right">Tokens</th>
+              <th class="text-right">Cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in usage.daily" :key="row.period">
+              <td>{{ row.period }}</td>
+              <td class="text-right">{{ formatNumber(row.requests) }}</td>
+              <td class="text-right">{{ formatNumber(row.total_tokens) }}</td>
+              <td class="text-right">{{ formatCost(row.cost) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <p
+      v-if="props.refreshInterval > 0"
+      class="text-xs text-base-content/50"
+      role="status"
+      aria-live="polite"
+    >
+      Live · refreshing every {{ Math.round(props.refreshInterval / 1000) }}s
+    </p>
+  </div>
+</template>

--- a/packages/vue/src/components/ai/UsageDashboard/UsageDashboard.vue
+++ b/packages/vue/src/components/ai/UsageDashboard/UsageDashboard.vue
@@ -78,12 +78,7 @@ onScopeDispose(() => {
 </script>
 
 <template>
-  <div
-    v-if="loading && !usage"
-    class="flex items-center gap-2"
-    role="status"
-    aria-live="polite"
-  >
+  <div v-if="loading && !usage" class="flex items-center gap-2" role="status" aria-live="polite">
     <span class="loading loading-spinner loading-sm" aria-hidden="true" />
     <span>Loading usage…</span>
   </div>
@@ -92,38 +87,43 @@ onScopeDispose(() => {
     <span>{{ error }}</span>
   </div>
 
-  <div
-    v-else-if="usage"
-    class="flex flex-col gap-6"
-    data-testid="ai-usage-dashboard"
-  >
-    <h2 v-if="heading" class="text-lg font-semibold">{{ heading }}</h2>
+  <div v-else-if="usage" class="flex flex-col gap-6" data-testid="ai-usage-dashboard">
+    <h2 v-if="heading" class="text-lg font-semibold">
+      {{ heading }}
+    </h2>
 
     <div class="stats stats-vertical sm:stats-horizontal shadow">
       <div class="stat">
         <div class="stat-title">Requests</div>
-        <div class="stat-value">{{ formatNumber(usage.totals.requests) }}</div>
+        <div class="stat-value">
+          {{ formatNumber(usage.totals.requests) }}
+        </div>
       </div>
       <div class="stat">
         <div class="stat-title">Input tokens</div>
-        <div class="stat-value">{{ formatNumber(usage.totals.input_tokens) }}</div>
+        <div class="stat-value">
+          {{ formatNumber(usage.totals.input_tokens) }}
+        </div>
       </div>
       <div class="stat">
         <div class="stat-title">Output tokens</div>
-        <div class="stat-value">{{ formatNumber(usage.totals.output_tokens) }}</div>
+        <div class="stat-value">
+          {{ formatNumber(usage.totals.output_tokens) }}
+        </div>
       </div>
       <div class="stat">
         <div class="stat-title">Cost</div>
-        <div class="stat-value">{{ formatCost(usage.totals.cost) }}</div>
+        <div class="stat-value">
+          {{ formatCost(usage.totals.cost) }}
+        </div>
       </div>
     </div>
 
     <section aria-labelledby="ai-usage-by-feature">
       <h3 id="ai-usage-by-feature" class="mb-2 font-medium">By feature</h3>
-      <p
-        v-if="usage.by_feature.length === 0"
-        class="text-sm text-base-content/70"
-      >No feature usage in this range.</p>
+      <p v-if="usage.by_feature.length === 0" class="text-sm text-base-content/70">
+        No feature usage in this range.
+      </p>
       <div v-else class="overflow-x-auto">
         <table class="table table-sm">
           <thead>
@@ -138,10 +138,18 @@ onScopeDispose(() => {
           <tbody>
             <tr v-for="row in usage.by_feature" :key="row.feature_key">
               <td>{{ row.feature_key }}</td>
-              <td class="text-right">{{ formatNumber(row.requests) }}</td>
-              <td class="text-right">{{ formatNumber(row.input_tokens) }}</td>
-              <td class="text-right">{{ formatNumber(row.output_tokens) }}</td>
-              <td class="text-right">{{ formatCost(row.cost) }}</td>
+              <td class="text-right">
+                {{ formatNumber(row.requests) }}
+              </td>
+              <td class="text-right">
+                {{ formatNumber(row.input_tokens) }}
+              </td>
+              <td class="text-right">
+                {{ formatNumber(row.output_tokens) }}
+              </td>
+              <td class="text-right">
+                {{ formatCost(row.cost) }}
+              </td>
             </tr>
           </tbody>
         </table>
@@ -150,10 +158,9 @@ onScopeDispose(() => {
 
     <section aria-labelledby="ai-usage-daily">
       <h3 id="ai-usage-daily" class="mb-2 font-medium">Daily</h3>
-      <p
-        v-if="usage.daily.length === 0"
-        class="text-sm text-base-content/70"
-      >No daily usage in this range.</p>
+      <p v-if="usage.daily.length === 0" class="text-sm text-base-content/70">
+        No daily usage in this range.
+      </p>
       <div v-else class="overflow-x-auto">
         <table class="table table-sm">
           <thead>
@@ -167,9 +174,15 @@ onScopeDispose(() => {
           <tbody>
             <tr v-for="row in usage.daily" :key="row.period">
               <td>{{ row.period }}</td>
-              <td class="text-right">{{ formatNumber(row.requests) }}</td>
-              <td class="text-right">{{ formatNumber(row.total_tokens) }}</td>
-              <td class="text-right">{{ formatCost(row.cost) }}</td>
+              <td class="text-right">
+                {{ formatNumber(row.requests) }}
+              </td>
+              <td class="text-right">
+                {{ formatNumber(row.total_tokens) }}
+              </td>
+              <td class="text-right">
+                {{ formatCost(row.cost) }}
+              </td>
             </tr>
           </tbody>
         </table>

--- a/packages/vue/src/components/ai/UsageDashboard/UsageDashboard.vue
+++ b/packages/vue/src/components/ai/UsageDashboard/UsageDashboard.vue
@@ -29,6 +29,7 @@ const usage = ref<AiUsageResponse | null>(null);
 const loading = ref(true);
 const error = ref<string | null>(null);
 let intervalId: ReturnType<typeof setInterval> | null = null;
+let requestSeq = 0;
 
 const formatNumber = (value: number): string => new Intl.NumberFormat().format(value);
 const formatCost = (value: number): string =>
@@ -40,20 +41,37 @@ const formatCost = (value: number): string =>
   }).format(value);
 
 async function load(): Promise<void> {
+  const seq = ++requestSeq;
   try {
     const response = await props.client.getUsage({ from: props.from, to: props.to });
+    // Discard responses that lost the race to a newer request — otherwise
+    // a slow-poll response can clobber a fresher one under high latency.
+    if (seq !== requestSeq) return;
     usage.value = response;
     error.value = null;
   } catch (err) {
+    if (seq !== requestSeq) return;
     error.value = (err as Error).message;
   } finally {
-    loading.value = false;
+    if (seq === requestSeq) {
+      loading.value = false;
+    }
   }
 }
 
 onMounted(() => {
   load();
 });
+
+// Reload when the date range changes so callers driving a date picker see
+// fresh data on every prop update, not just at mount / poll tick.
+watch(
+  () => [props.from, props.to],
+  () => {
+    loading.value = true;
+    load();
+  },
+);
 
 watch(
   () => props.refreshInterval,

--- a/packages/vue/src/components/ai/createAiApiClient.ts
+++ b/packages/vue/src/components/ai/createAiApiClient.ts
@@ -56,7 +56,9 @@ export function createAiApiClient(options: CreateAiApiClientOptions): AiApiClien
     const search = query
       ? '?' +
         new URLSearchParams(
-          Object.entries(query).flatMap(([k, v]) => (v == null ? [] : [[k, v] as [string, string]])),
+          Object.entries(query).flatMap(([k, v]) =>
+            v == null ? [] : [[k, v] as [string, string]],
+          ),
         ).toString()
       : '';
     const response = await doFetch(`${trimmedBase}${path}${search}`, {

--- a/packages/vue/src/components/ai/createAiApiClient.ts
+++ b/packages/vue/src/components/ai/createAiApiClient.ts
@@ -1,0 +1,117 @@
+/** @module ai/createAiApiClient */
+
+import type {
+  AiApiClient,
+  AiConnectionTestResult,
+  AiFeature,
+  AiSettingsResponse,
+  AiSettingsUpdate,
+  AiUsageResponse,
+} from './types';
+
+/**
+ * Options for {@link createAiApiClient}.
+ */
+export interface CreateAiApiClientOptions {
+  /** Base URL of the AI JSON API, e.g. `'/api/artisanpack-ai'`. */
+  baseUrl: string;
+  /** Optional `fetch` override (for tests or custom auth wrappers). */
+  fetchImpl?: typeof fetch;
+  /** Extra headers merged into every request (e.g. `{ 'X-CSRF-TOKEN': token }`). */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Thrown when the AI API returns a non-2xx response. Includes the parsed body
+ * so consumers can surface validation errors returned as `{ errors: ... }`.
+ */
+export class AiApiError extends Error {
+  public readonly status: number;
+  public readonly body: unknown;
+
+  constructor(status: number, body: unknown, message: string) {
+    super(message);
+    this.name = 'AiApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Create a small {@link AiApiClient} that wraps `fetch` calls to the
+ * artisanpack-ui/ai JSON API endpoints. Non-2xx responses reject with
+ * {@link AiApiError}.
+ */
+export function createAiApiClient(options: CreateAiApiClientOptions): AiApiClient {
+  const { baseUrl, fetchImpl, headers: extraHeaders } = options;
+  const doFetch = fetchImpl ?? globalThis.fetch;
+
+  const trimmedBase = baseUrl.replace(/\/$/, '');
+
+  async function request<T>(
+    path: string,
+    init: RequestInit = {},
+    query?: Record<string, string | undefined>,
+  ): Promise<T> {
+    const search = query
+      ? '?' +
+        new URLSearchParams(
+          Object.entries(query).flatMap(([k, v]) => (v == null ? [] : [[k, v] as [string, string]])),
+        ).toString()
+      : '';
+    const response = await doFetch(`${trimmedBase}${path}${search}`, {
+      ...init,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...extraHeaders,
+        ...init.headers,
+      },
+    });
+
+    const raw = await response.text();
+    let body: unknown = null;
+    if (raw.length > 0) {
+      try {
+        body = JSON.parse(raw);
+      } catch {
+        body = raw;
+      }
+    }
+
+    if (!response.ok) {
+      const message =
+        (body && typeof body === 'object' && 'message' in body && typeof body.message === 'string'
+          ? body.message
+          : null) ?? `AI API request to ${path} failed with status ${response.status}`;
+      throw new AiApiError(response.status, body, message);
+    }
+
+    return body as T;
+  }
+
+  return {
+    getSettings: () => request<AiSettingsResponse>('/settings'),
+    updateSettings: (body: AiSettingsUpdate) =>
+      request<AiSettingsResponse>('/settings', {
+        method: 'PUT',
+        body: JSON.stringify(body),
+      }),
+    testConnection: (body) =>
+      request<AiConnectionTestResult>('/test-connection', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      }),
+    getFeatures: () => request<{ features: AiFeature[] }>('/features'),
+    toggleFeature: (key: string, enabled?: boolean) =>
+      request<{ feature: Pick<AiFeature, 'key' | 'package' | 'enabled'> }>(
+        `/features/${encodeURIComponent(key)}/toggle`,
+        {
+          method: 'POST',
+          body: JSON.stringify(enabled === undefined ? {} : { enabled }),
+        },
+      ),
+    getUsage: (params) =>
+      request<AiUsageResponse>('/usage', {}, { from: params?.from, to: params?.to }),
+  };
+}

--- a/packages/vue/src/components/ai/createAiApiClient.ts
+++ b/packages/vue/src/components/ai/createAiApiClient.ts
@@ -53,19 +53,23 @@ export function createAiApiClient(options: CreateAiApiClientOptions): AiApiClien
     init: RequestInit = {},
     query?: Record<string, string | undefined>,
   ): Promise<T> {
-    const search = query
-      ? '?' +
-        new URLSearchParams(
+    const searchParams = query
+      ? new URLSearchParams(
           Object.entries(query).flatMap(([k, v]) =>
             v == null ? [] : [[k, v] as [string, string]],
           ),
         ).toString()
       : '';
+    const search = searchParams === '' ? '' : `?${searchParams}`;
+    // Only advertise a JSON request body on methods that actually carry one —
+    // strict reverse-proxies and Sanctum form-request configs reject GET/DELETE
+    // requests that ship a Content-Type without a body.
+    const hasBody = init.body != null;
     const response = await doFetch(`${trimmedBase}${path}${search}`, {
       ...init,
       headers: {
         Accept: 'application/json',
-        'Content-Type': 'application/json',
+        ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
         ...extraHeaders,
         ...init.headers,
       },

--- a/packages/vue/src/components/ai/index.ts
+++ b/packages/vue/src/components/ai/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @module ai
+ *
+ * Vue components + composables for consuming the artisanpack-ui/ai JSON API.
+ * Shipped as the `@artisanpack-ui/vue/ai` subpath.
+ *
+ * @example
+ * ```ts
+ * import { createAiApiClient, SettingsPage, UsageDashboard, FeatureToggles } from '@artisanpack-ui/vue/ai';
+ * ```
+ */
+
+export { default as SettingsPage } from './SettingsPage/SettingsPage.vue';
+export { default as UsageDashboard } from './UsageDashboard/UsageDashboard.vue';
+export { default as FeatureToggles } from './FeatureToggles/FeatureToggles.vue';
+
+export { createAiApiClient, AiApiError } from './createAiApiClient';
+export type { CreateAiApiClientOptions } from './createAiApiClient';
+
+export { useStreamingText } from './useStreamingText';
+export type { UseStreamingTextResult } from './useStreamingText';
+
+export type {
+  AiApiClient,
+  AiCredentials,
+  AiFeature,
+  AiFeatureOverride,
+  AiSettingsResponse,
+  AiSettingsUpdate,
+  AiConnectionTestResult,
+  AiUsageTotals,
+  AiUsageByFeature,
+  AiUsageDaily,
+  AiUsageResponse,
+  AiValidationError,
+} from './types';

--- a/packages/vue/src/components/ai/mockClient.ts
+++ b/packages/vue/src/components/ai/mockClient.ts
@@ -1,0 +1,75 @@
+/** @module ai/mockClient */
+
+import type { AiApiClient, AiSettingsResponse, AiUsageResponse, AiFeature } from './types';
+
+/**
+ * In-memory {@link AiApiClient} for Storybook stories and demos. All methods
+ * resolve after a short delay so loading states are visible.
+ *
+ * @internal
+ */
+export function createStorybookMockClient(): AiApiClient {
+  let settings: AiSettingsResponse = {
+    credentials: {
+      provider: 'openai',
+      api_key_present: true,
+      base_url: null,
+      default_model: 'gpt-4o-mini',
+    },
+    feature_overrides: [
+      { feature_key: 'summarize', package: 'core', model: null, instructions: null },
+      { feature_key: 'chat', package: 'core', model: 'gpt-4o', instructions: 'Be concise.' },
+    ],
+  };
+
+  let features: AiFeature[] = [
+    { key: 'summarize', package: 'core', label: 'Summarize', description: 'AI-generated summaries', enabled: true },
+    { key: 'chat', package: 'core', label: 'Chat', description: 'Assistant chat surface', enabled: false },
+  ];
+
+  const usage: AiUsageResponse = {
+    range: { from: '2026-07-01T00:00:00+00:00', to: '2026-07-31T23:59:59+00:00' },
+    totals: { requests: 42, input_tokens: 12_000, output_tokens: 4_800, total_tokens: 16_800, cost: 1.24 },
+    by_feature: [
+      { feature_key: 'summarize', requests: 30, input_tokens: 9_000, output_tokens: 3_000, total_tokens: 12_000, cost: 0.9 },
+      { feature_key: 'chat', requests: 12, input_tokens: 3_000, output_tokens: 1_800, total_tokens: 4_800, cost: 0.34 },
+    ],
+    daily: [
+      { period: '2026-07-04', requests: 20, input_tokens: 6_000, output_tokens: 2_000, total_tokens: 8_000, cost: 0.6 },
+      { period: '2026-07-05', requests: 22, input_tokens: 6_000, output_tokens: 2_800, total_tokens: 8_800, cost: 0.64 },
+    ],
+  };
+
+  const delay = <T,>(value: T) => new Promise<T>((resolve) => setTimeout(() => resolve(value), 200));
+
+  return {
+    getSettings: () => delay(settings),
+    updateSettings: (body) => {
+      settings = {
+        credentials: {
+          provider: body.provider,
+          api_key_present: settings.credentials.api_key_present || !!body.api_key,
+          base_url: body.base_url ?? null,
+          default_model: body.default_model ?? null,
+        },
+        feature_overrides:
+          body.feature_overrides?.map((row) => ({
+            feature_key: row.feature_key,
+            package: settings.feature_overrides.find((o) => o.feature_key === row.feature_key)?.package ?? 'core',
+            model: row.model ?? null,
+            instructions: row.instructions ?? null,
+          })) ?? settings.feature_overrides,
+      };
+      return delay(settings);
+    },
+    testConnection: (body) =>
+      delay({ result: 'ok' as const, message: `Connected to ${body.provider}`, provider: body.provider }),
+    getFeatures: () => delay({ features }),
+    toggleFeature: (key, enabled) => {
+      features = features.map((f) => (f.key === key ? { ...f, enabled: enabled ?? !f.enabled } : f));
+      const updated = features.find((f) => f.key === key)!;
+      return delay({ feature: { key: updated.key, package: updated.package, enabled: updated.enabled } });
+    },
+    getUsage: () => delay(usage),
+  };
+}

--- a/packages/vue/src/components/ai/mockClient.ts
+++ b/packages/vue/src/components/ai/mockClient.ts
@@ -23,24 +23,70 @@ export function createStorybookMockClient(): AiApiClient {
   };
 
   let features: AiFeature[] = [
-    { key: 'summarize', package: 'core', label: 'Summarize', description: 'AI-generated summaries', enabled: true },
-    { key: 'chat', package: 'core', label: 'Chat', description: 'Assistant chat surface', enabled: false },
+    {
+      key: 'summarize',
+      package: 'core',
+      label: 'Summarize',
+      description: 'AI-generated summaries',
+      enabled: true,
+    },
+    {
+      key: 'chat',
+      package: 'core',
+      label: 'Chat',
+      description: 'Assistant chat surface',
+      enabled: false,
+    },
   ];
 
   const usage: AiUsageResponse = {
     range: { from: '2026-07-01T00:00:00+00:00', to: '2026-07-31T23:59:59+00:00' },
-    totals: { requests: 42, input_tokens: 12_000, output_tokens: 4_800, total_tokens: 16_800, cost: 1.24 },
+    totals: {
+      requests: 42,
+      input_tokens: 12_000,
+      output_tokens: 4_800,
+      total_tokens: 16_800,
+      cost: 1.24,
+    },
     by_feature: [
-      { feature_key: 'summarize', requests: 30, input_tokens: 9_000, output_tokens: 3_000, total_tokens: 12_000, cost: 0.9 },
-      { feature_key: 'chat', requests: 12, input_tokens: 3_000, output_tokens: 1_800, total_tokens: 4_800, cost: 0.34 },
+      {
+        feature_key: 'summarize',
+        requests: 30,
+        input_tokens: 9_000,
+        output_tokens: 3_000,
+        total_tokens: 12_000,
+        cost: 0.9,
+      },
+      {
+        feature_key: 'chat',
+        requests: 12,
+        input_tokens: 3_000,
+        output_tokens: 1_800,
+        total_tokens: 4_800,
+        cost: 0.34,
+      },
     ],
     daily: [
-      { period: '2026-07-04', requests: 20, input_tokens: 6_000, output_tokens: 2_000, total_tokens: 8_000, cost: 0.6 },
-      { period: '2026-07-05', requests: 22, input_tokens: 6_000, output_tokens: 2_800, total_tokens: 8_800, cost: 0.64 },
+      {
+        period: '2026-07-04',
+        requests: 20,
+        input_tokens: 6_000,
+        output_tokens: 2_000,
+        total_tokens: 8_000,
+        cost: 0.6,
+      },
+      {
+        period: '2026-07-05',
+        requests: 22,
+        input_tokens: 6_000,
+        output_tokens: 2_800,
+        total_tokens: 8_800,
+        cost: 0.64,
+      },
     ],
   };
 
-  const delay = <T,>(value: T) => new Promise<T>((resolve) => setTimeout(() => resolve(value), 200));
+  const delay = <T>(value: T) => new Promise<T>((resolve) => setTimeout(() => resolve(value), 200));
 
   return {
     getSettings: () => delay(settings),
@@ -55,7 +101,9 @@ export function createStorybookMockClient(): AiApiClient {
         feature_overrides:
           body.feature_overrides?.map((row) => ({
             feature_key: row.feature_key,
-            package: settings.feature_overrides.find((o) => o.feature_key === row.feature_key)?.package ?? 'core',
+            package:
+              settings.feature_overrides.find((o) => o.feature_key === row.feature_key)?.package ??
+              'core',
             model: row.model ?? null,
             instructions: row.instructions ?? null,
           })) ?? settings.feature_overrides,
@@ -63,12 +111,20 @@ export function createStorybookMockClient(): AiApiClient {
       return delay(settings);
     },
     testConnection: (body) =>
-      delay({ result: 'ok' as const, message: `Connected to ${body.provider}`, provider: body.provider }),
+      delay({
+        result: 'ok' as const,
+        message: `Connected to ${body.provider}`,
+        provider: body.provider,
+      }),
     getFeatures: () => delay({ features }),
     toggleFeature: (key, enabled) => {
-      features = features.map((f) => (f.key === key ? { ...f, enabled: enabled ?? !f.enabled } : f));
+      features = features.map((f) =>
+        f.key === key ? { ...f, enabled: enabled ?? !f.enabled } : f,
+      );
       const updated = features.find((f) => f.key === key)!;
-      return delay({ feature: { key: updated.key, package: updated.package, enabled: updated.enabled } });
+      return delay({
+        feature: { key: updated.key, package: updated.package, enabled: updated.enabled },
+      });
     },
     getUsage: () => delay(usage),
   };

--- a/packages/vue/src/components/ai/types.ts
+++ b/packages/vue/src/components/ai/types.ts
@@ -1,0 +1,105 @@
+/** @module ai/types */
+
+/** Public credential payload returned from GET `/settings`. Never contains the plaintext API key. */
+export interface AiCredentials {
+  provider: string;
+  api_key_present: boolean;
+  base_url: string | null;
+  default_model: string | null;
+}
+
+/** Per-feature override row returned from GET `/settings`. */
+export interface AiFeatureOverride {
+  feature_key: string;
+  package: string;
+  model: string | null;
+  instructions: string | null;
+}
+
+/** Combined settings payload from GET `/settings`. */
+export interface AiSettingsResponse {
+  credentials: AiCredentials;
+  feature_overrides: AiFeatureOverride[];
+}
+
+/** Body for PUT `/settings`. `api_key` is optional; omit to keep the stored key. */
+export interface AiSettingsUpdate {
+  provider: string;
+  api_key?: string | null;
+  base_url?: string | null;
+  default_model?: string | null;
+  feature_overrides?: Array<Pick<AiFeatureOverride, 'feature_key' | 'model' | 'instructions'>>;
+}
+
+/** Feature row returned from GET `/features`. */
+export interface AiFeature {
+  key: string;
+  package: string;
+  label: string;
+  description: string | null;
+  enabled: boolean;
+}
+
+/** Response from POST `/test-connection`. */
+export interface AiConnectionTestResult {
+  result: 'ok' | 'error';
+  message?: string;
+  provider?: string;
+  model?: string | null;
+}
+
+/** Usage totals block from GET `/usage`. */
+export interface AiUsageTotals {
+  requests: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cost: number;
+}
+
+/** Per-feature usage row. */
+export interface AiUsageByFeature {
+  feature_key: string;
+  requests: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cost: number;
+}
+
+/** Daily usage bucket. */
+export interface AiUsageDaily {
+  period: string;
+  requests: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cost: number;
+}
+
+/** Full response body of GET `/usage`. */
+export interface AiUsageResponse {
+  range: { from: string; to: string };
+  totals: AiUsageTotals;
+  by_feature: AiUsageByFeature[];
+  daily: AiUsageDaily[];
+}
+
+/** Validation error envelope returned by 422 responses. */
+export interface AiValidationError {
+  message: string;
+  errors: Record<string, string[]>;
+}
+
+/**
+ * Minimal HTTP client contract. Callers inject their own fetch wrapper
+ * (typically pre-configured with base URL, CSRF token, and Accept: application/json).
+ */
+export interface AiApiClient {
+  getSettings(): Promise<AiSettingsResponse>;
+  updateSettings(body: AiSettingsUpdate): Promise<AiSettingsResponse>;
+  testConnection(body: Omit<AiSettingsUpdate, 'feature_overrides'>): Promise<AiConnectionTestResult>;
+  getFeatures(): Promise<{ features: AiFeature[] }>;
+  toggleFeature(key: string, enabled?: boolean): Promise<{ feature: Pick<AiFeature, 'key' | 'package' | 'enabled'> }>;
+  getUsage(params?: { from?: string; to?: string }): Promise<AiUsageResponse>;
+}

--- a/packages/vue/src/components/ai/types.ts
+++ b/packages/vue/src/components/ai/types.ts
@@ -98,8 +98,13 @@ export interface AiValidationError {
 export interface AiApiClient {
   getSettings(): Promise<AiSettingsResponse>;
   updateSettings(body: AiSettingsUpdate): Promise<AiSettingsResponse>;
-  testConnection(body: Omit<AiSettingsUpdate, 'feature_overrides'>): Promise<AiConnectionTestResult>;
+  testConnection(
+    body: Omit<AiSettingsUpdate, 'feature_overrides'>,
+  ): Promise<AiConnectionTestResult>;
   getFeatures(): Promise<{ features: AiFeature[] }>;
-  toggleFeature(key: string, enabled?: boolean): Promise<{ feature: Pick<AiFeature, 'key' | 'package' | 'enabled'> }>;
+  toggleFeature(
+    key: string,
+    enabled?: boolean,
+  ): Promise<{ feature: Pick<AiFeature, 'key' | 'package' | 'enabled'> }>;
   getUsage(params?: { from?: string; to?: string }): Promise<AiUsageResponse>;
 }

--- a/packages/vue/src/components/ai/useStreamingText.ts
+++ b/packages/vue/src/components/ai/useStreamingText.ts
@@ -1,0 +1,91 @@
+/** @module ai/useStreamingText */
+
+import { onScopeDispose, ref, type Ref } from 'vue';
+
+/**
+ * Result of {@link useStreamingText}.
+ */
+export interface UseStreamingTextResult {
+  /** Accumulated text chunks received so far. */
+  text: Ref<string>;
+  /** True while a stream is actively being consumed. */
+  streaming: Ref<boolean>;
+  /** Populated when the stream ends with an error. */
+  error: Ref<Error | null>;
+  /**
+   * Kick off a stream from the given URL. Aborts any in-flight stream first.
+   * Chunks decoded from `Response.body` are appended to `text` as they arrive.
+   */
+  start: (url: string, init?: RequestInit) => Promise<void>;
+  /** Abort the in-flight stream, if any. */
+  stop: () => void;
+  /** Reset accumulated text and error state. */
+  reset: () => void;
+}
+
+/**
+ * Consume a long-running fetch response as a UTF-8 text stream, appending
+ * decoded chunks to `text` on each read.
+ *
+ * Wraps the browser Streams API and cleans up its abort controller when the
+ * calling scope is disposed. Useful for the AI usage dashboard's long-running
+ * agent output surface.
+ */
+export function useStreamingText(): UseStreamingTextResult {
+  const text = ref('');
+  const streaming = ref(false);
+  const error = ref<Error | null>(null);
+  let controller: AbortController | null = null;
+
+  function stop(): void {
+    controller?.abort();
+    controller = null;
+    streaming.value = false;
+  }
+
+  function reset(): void {
+    text.value = '';
+    error.value = null;
+  }
+
+  async function start(url: string, init?: RequestInit): Promise<void> {
+    controller?.abort();
+    const localController = new AbortController();
+    controller = localController;
+
+    text.value = '';
+    error.value = null;
+    streaming.value = true;
+
+    try {
+      const response = await fetch(url, { ...init, signal: localController.signal });
+      if (!response.ok || !response.body) {
+        throw new Error(`Stream request failed with status ${response.status}`);
+      }
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        text.value += decoder.decode(value, { stream: true });
+      }
+      text.value += decoder.decode();
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        error.value = err as Error;
+      }
+    } finally {
+      if (controller === localController) {
+        controller = null;
+      }
+      streaming.value = false;
+    }
+  }
+
+  onScopeDispose(() => {
+    controller?.abort();
+  });
+
+  return { text, streaming, error, start, stop, reset };
+}

--- a/packages/vue/src/components/ai/useStreamingText.ts
+++ b/packages/vue/src/components/ai/useStreamingText.ts
@@ -64,7 +64,6 @@ export function useStreamingText(): UseStreamingTextResult {
       }
       const reader = response.body.getReader();
       const decoder = new TextDecoder();
-      // eslint-disable-next-line no-constant-condition
       while (true) {
         const { value, done } = await reader.read();
         if (done) break;

--- a/packages/vue/src/components/ai/useStreamingText.ts
+++ b/packages/vue/src/components/ai/useStreamingText.ts
@@ -75,10 +75,14 @@ export function useStreamingText(): UseStreamingTextResult {
         error.value = err as Error;
       }
     } finally {
+      // Only flip streaming off if we're still the active stream. Otherwise
+      // a rapid second start() would race: this stream's finally would clear
+      // the flag while the newer stream is still reading, and consumers gating
+      // spinners on `streaming` would render as done mid-stream.
       if (controller === localController) {
         controller = null;
+        streaming.value = false;
       }
-      streaming.value = false;
     }
   }
 

--- a/packages/vue/tsup.config.ts
+++ b/packages/vue/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     feedback: 'src/components/feedback/index.ts',
     utility: 'src/components/utility/index.ts',
     composables: 'src/composables/index.ts',
+    ai: 'src/components/ai/index.ts',
   },
   format: ['esm'],
   dts: false,


### PR DESCRIPTION
## Description

Ships a new `@artisanpack-ui/vue/ai` subpath containing Vue 3 components for the artisanpack-ui/ai admin surfaces. Consumes the JSON API endpoints already shipping on ai `release/1.0`.

**Closes:** ArtisanPack-UI/ai#18

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** ArtisanPack-UI/ai#18

## Motivation and Context

Vue starter kit users need parity with the Livewire admin surfaces shipped in ai v1.0 — a set of drop-in components that consume the same JSON API without pulling in Livewire.

## Changes Made

- New `src/components/ai/` subpath with:
  - `SettingsPage.vue` — GET/PUT `/settings` + `test-connection` probe, per-feature overrides
  - `UsageDashboard.vue` — GET `/usage` with `refreshInterval` polling for live updates
  - `FeatureToggles.vue` — GET `/features` + optimistic POST `/features/{key}/toggle` with rollback on failure
  - `createAiApiClient` — fetch wrapper with `AiApiError` for surfacing 422 payloads
  - `useStreamingText` — composable for consuming long-running agent-output streams (Streams API + abort via `onScopeDispose`)
- Wired into `tsup.config.ts` and `package.json` exports as `./ai`
- 16 Vitest cases across the four modules

Types, `createAiApiClient`, and `mockClient` are ported verbatim from `@artisanpack-ui/react`'s port (ArtisanPack-UI/react#45) so both packages share the same wire-level contract.

## How Has This Been Tested?

**Tests Performed:**
1. `npx vitest run __tests__/ai` — 16/16 passing
2. `npx vitest run` — 708/717 passing. 9 pre-existing `ThemeToggle` failures are present on `release/1.0.1` unchanged; unrelated to this PR.
3. `npm run build` — tsup emits `dist/ai.mjs` cleanly

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked

**Details:** Interactive controls carry explicit `aria-label` / `aria-live`. Toggles expose `sr-only` labels; loading/error states use `role="status"` / `role="alert"`.

## Tests Added

- [x] Unit tests added/updated
- [x] All new tests passing

## Follow-ups (not blocking merge)

- **Histoire stories** — issue #18 doesn't require them, but adding `.story.vue` files would match the pattern used by every other component in this package. Track as a follow-up.
- **vue-starter-kit end-to-end wiring** — no `vue-starter-kit` package exists yet under `~/Code/ArtisanPack UI Packages/`. Track as a separate issue once that repo lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
